### PR TITLE
fix(ble): recover from lost release frames stalling page turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Changed
 - Default `tiny` build now omits the Teensy (8px) font variant to make room for the NimBLE-Arduino BLE stack. Re-enable by removing `OMIT_TEENSY_FONT` from `platformio.ini` if you don't need Bluetooth.
 
+### Fixed
+- BLE page-turner could hang at chapter boundaries when a release HID frame was dropped (NimBLE task starvation during the heavy section-load render is a common trigger). Subsequent presses were silently filtered out by both the BLE-side `activeInjectedButton` gate and HalGPIO's same-state short-circuit, requiring a book exit/re-enter to recover. Added two backstops: a 2 s max-hold auto-release on virtual buttons (suppressed release edge so no phantom page turn fires), and a force-release of a stuck injection in Game Brick's same-key re-press promotion path.
+
 ## [v1.2.9.1] - 2026-05-03
 
 ### Changed

--- a/lib/hal/BluetoothHIDManager.cpp
+++ b/lib/hal/BluetoothHIDManager.cpp
@@ -1181,6 +1181,17 @@ void BluetoothHIDManager::onHIDNotify(NimBLERemoteCharacteristic* pChar, uint8_t
       isNewPressEvent = true;
       device->lastButtonState = false;
       device->lastNormalizedPressed = false;
+      // A same-key re-press after this much idle means we missed the previous
+      // release frame (BLE callback starved during a heavy chapter render is a
+      // common trigger). Force-release the stuck injection so the press path
+      // below treats this as a fresh tap; otherwise the `activeInjectedButton`
+      // gate at the injector block would silently swallow it.
+      if (device->activeInjectedButton != 0xFF) {
+        if (g_instance->_buttonInjector) {
+          g_instance->_buttonInjector(device->activeInjectedButton, false);
+        }
+        device->activeInjectedButton = 0xFF;
+      }
       LOG_DBG("BT", "Game Brick: promoting same-key re-press after %lu ms idle (key=0x%02X)",
               nowMs - device->lastNormalizedEventMs, keycode);
     }

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -209,11 +209,40 @@ void HalGPIO::begin() {
 
 namespace {
 constexpr unsigned long VIRTUAL_BUTTON_REPRESS_DEBOUNCE_MS = 250;
+// Backstop for lost BLE release frames. If a BLE HID release report is dropped
+// (NimBLE task starvation during a heavy chapter render, or a flaky remote),
+// the virtual button bit can stay latched forever -- and `setVirtualButtonState`
+// short-circuits same-state updates, so no later press will ever re-arm the
+// rising edge. After this many ms with the bit set, force-clear it so the
+// reader recovers without needing a book exit/re-enter.
+// Must stay comfortably above the reader's 700 ms long-press chapter-skip
+// threshold so legitimate holds aren't cut short.
+constexpr unsigned long VIRTUAL_BUTTON_MAX_HOLD_MS = 2000;
 }
 
 void HalGPIO::update() {
   previousVirtualButtonState = virtualButtonState;
   virtualButtonState = desiredVirtualButtonState;
+
+  // Auto-release any virtual button that has been latched "pressed" past the
+  // safety threshold. Suppress the release edge (clear both current and
+  // previous bits) so the reader doesn't see a phantom wasReleased -- by the
+  // time we hit this threshold, the user has long since given up and a
+  // delayed page turn would be worse than silent recovery.
+  const unsigned long nowMs = millis();
+  for (uint8_t buttonIndex = 0; buttonIndex <= BTN_POWER; ++buttonIndex) {
+    const uint8_t mask = (1 << buttonIndex);
+    if ((virtualButtonState & mask) == 0) continue;
+    if (virtualPressStart[buttonIndex] == 0) continue;
+    if ((nowMs - virtualPressStart[buttonIndex]) <= VIRTUAL_BUTTON_MAX_HOLD_MS) continue;
+
+    virtualButtonState &= ~mask;
+    previousVirtualButtonState &= ~mask;
+    desiredVirtualButtonState &= ~mask;
+    virtualPressFinish[buttonIndex] = nowMs;
+    virtualPressStart[buttonIndex] = 0;
+    virtualLastActivityTime[buttonIndex] = 0;
+  }
 
   inputMgr.update();
   const bool connected = isUsbConnected();


### PR DESCRIPTION
## Summary
- BLE page-turner could hang at chapter boundaries: a dropped release HID report latches the page-forward virtual button, and from then on `setVirtualButtonState`'s same-state short-circuit silently swallows every subsequent press. Only fix was to exit the book (BLE auto-disconnect clears both state machines) and re-enter.
- Two backstops, one per state machine, so a lost release on any profile self-recovers.

## Root cause
On single-core ESP32-C3, a heavy chapter-load render (`section.reset()` -> `requestUpdate()` -> `loadSectionFile`/`createSectionFile` under the render lock) can starve the NimBLE task long enough that an incoming release HID frame gets dropped at the controller. That leaves two pieces of state stuck:

- **`HalGPIO::desiredVirtualButtonState`** — the page-forward bit stays set. `wasPressed = virtual & ~previous` returns false on every subsequent main-loop poll because there's no rising edge.
- **`BluetoothHIDManager::ConnectedDevice::activeInjectedButton`** — the gate at the injection block (`activeInjectedButton == 0xFF`) keeps any new injection from firing.

Existing safety nets don't catch this combination:
- Game Brick's 1200 ms stale-hold reset is gated on `(now - lastNormalizedEventMs) > 1200`, but every new press report refreshes `lastNormalizedEventMs`, so an impatient user keeps the reset perpetually deferred.
- Free2's stale-release maintenance is profile-gated.
- Non-Free2 maintenance runs every 10 s — useful but too slow to feel responsive.
- Game Brick's 220 ms same-key re-press promotion (line 1177) cleared `lastButtonState` but **not** `activeInjectedButton`, so the injection block still skipped.

Without BT, none of this applies — physical buttons don't go through the virtual-button path at all.

## Changes
- **`lib/hal/HalGPIO.cpp`** — `update()` auto-clears any virtual bit held past 2000 ms. Suppresses the release edge (clears `previous` + `current` + `desired` in lock-step) so the reader doesn't see a phantom `wasReleased` and fire a delayed page turn. Threshold chosen comfortably above the reader's 700 ms long-press chapter-skip threshold.
- **`lib/hal/BluetoothHIDManager.cpp`** — Game Brick's same-key re-press promotion now also force-releases `activeInjectedButton`, so the injection block at line 1318 re-arms on the very next press instead of silently skipping.
- **`CHANGELOG.md`** — Fixed entry under `[Unreleased]`.

## Test plan
- [x] Builds clean on `tiny` env.
- [x] Flashed to X4.
- [ ] Read across several chapter boundaries with a paired Game Brick — confirm forward presses always advance (no Back x2 escape needed).
- [ ] Spam-tap forward across a boundary right as the new chapter is rendering — verify recovery within ~220 ms (GB path) or 2 s worst case.
- [ ] Long-press chapter skip (>= 700 ms held) still works; not cut short by the 2 s auto-release.
- [ ] Physical-button page turns unaffected (separate code path).