### PR TITLE
fix: drawer/carousel/BLE bundle + Indexing animation + new defaults

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1795,6 +1795,14 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   // build on big chapters.
   uint32_t lastPopupTick = millis();
   constexpr uint32_t kPopupTickMs = 250;
+  // CrumBLE: diagnostics for chapters where the parser appears to hang.
+  // Log per-iteration progress so a serial monitor user can see exactly
+  // which chunk the parser stalls in (file offset, free heap, elapsed).
+  // Also call yield() each iteration to feed the FreeRTOS task watchdog
+  // — without it, a chapter whose handlers take >5 s per chunk would
+  // eventually trip a watchdog reset, which the user could perceive as
+  // "freeze then reboot".
+  uint32_t iterCount = 0;
   do {
     if (popupFn && (millis() - lastPopupTick) >= kPopupTickMs) {
       popupFn();
@@ -1808,7 +1816,9 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       return false;
     }
 
+    const uint32_t iterStart = millis();
     const size_t len = file.read(buf, PARSE_BUFFER_SIZE);
+    const uint32_t afterReadMs = millis();
 
     if (len == 0 && file.available() > 0) {
       LOG_ERR("EHP", "File read error");
@@ -1826,6 +1836,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       file.close();
       return false;
     }
+    const uint32_t afterParseMs = millis();
 
     if (lowMemoryAbort) {
       LOG_ERR("EHP", "Aborting section parse due to low heap");
@@ -1833,6 +1844,20 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       file.close();
       return false;
     }
+
+    // Per-chunk progress log. DBG-level so it's compiled out at the
+    // production LOG_LEVEL=1 setting and only shows up in debug builds
+    // (LOG_LEVEL=2) when diagnosing a slow / hung parse. The fields
+    // (file offset, read/parse ms, free heap, elapsed) are enough to
+    // pinpoint which chunk stalls and what the heap looked like there.
+    LOG_DBG("EHP", "iter=%lu pos=%lu/%lu read_ms=%lu parse_ms=%lu free=%u maxAlloc=%u elapsed=%lu",
+            static_cast<unsigned long>(iterCount), static_cast<unsigned long>(file.position()),
+            static_cast<unsigned long>(file.size()), static_cast<unsigned long>(afterReadMs - iterStart),
+            static_cast<unsigned long>(afterParseMs - afterReadMs), ESP.getFreeHeap(), ESP.getMaxAllocHeap(),
+            static_cast<unsigned long>(millis() - chapterStartTime));
+    iterCount++;
+    // Feed the task watchdog so a slow chunk doesn't trip a reset.
+    yield();
 
   } while (!done);
   LOG_DBG("EHP", "Time to parse and build pages: %lu ms (free=%u, maxAlloc=%u)", millis() - chapterStartTime,

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1787,7 +1787,19 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
 
   // Compute the time taken to parse and build pages
   const uint32_t chapterStartTime = millis();
+  // CrumBLE: tick the popup callback every ~250 ms during the parse so
+  // the caller can animate (e.g. cycling "Indexing." / ".." / "...") and
+  // give the user feedback that the system is alive on long parses.
+  // The popup was previously drawn once at the start of the chapter and
+  // never updated, so the screen looked frozen for the whole 10+ second
+  // build on big chapters.
+  uint32_t lastPopupTick = millis();
+  constexpr uint32_t kPopupTickMs = 250;
   do {
+    if (popupFn && (millis() - lastPopupTick) >= kPopupTickMs) {
+      popupFn();
+      lastPopupTick = millis();
+    }
     void* const buf = XML_GetBuffer(parser, PARSE_BUFFER_SIZE);
     if (!buf) {
       LOG_ERR("EHP", "Couldn't allocate memory for buffer");

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1873,16 +1873,27 @@ void GfxRenderer::freeBwCompressedBackup() {
  * compressed buffer couldn't be allocated or the data overflowed.
  */
 bool GfxRenderer::storeBwBuffer() {
-  if (bwCompressedBackup) {
-    LOG_ERR("GFX", "!! BW backup already stored - freeing previous");
-    freeBwCompressedBackup();
-  }
-
-  bwCompressedBackup = static_cast<uint8_t*>(malloc(MAX_BW_COMPRESSED_SIZE));
-  if (!bwCompressedBackup) {
-    LOG_ERR("GFX", "!! Failed to allocate BW compressed backup (%zu bytes)", MAX_BW_COMPRESSED_SIZE);
+  // Allocate the new buffer BEFORE freeing the existing backup. Under
+  // heap pressure (e.g. NimBLE's ~58 KB share) the malloc can fail, and
+  // we used to free the previous backup unconditionally — which left the
+  // caller with no usable framebuffer snapshot at all. The BookSettings
+  // drawer's onEnter triggers exactly this path: it calls storeBwBuffer
+  // right after the reader's render finished (which left its own backup
+  // around), and a malloc failure used to clobber the reader's backup
+  // and force the drawer to clearScreen(), producing a white background
+  // behind the panel.
+  uint8_t* const newBackup = static_cast<uint8_t*>(malloc(MAX_BW_COMPRESSED_SIZE));
+  if (!newBackup) {
+    LOG_ERR("GFX", "!! Failed to allocate BW compressed backup (%zu bytes); existing backup (if any) preserved",
+            MAX_BW_COMPRESSED_SIZE);
     return false;
   }
+
+  if (bwCompressedBackup) {
+    LOG_DBG("GFX", "BW backup already stored - freeing previous for new snapshot");
+    freeBwCompressedBackup();
+  }
+  bwCompressedBackup = newBackup;
 
   const uint8_t* src = frameBuffer;
   const uint8_t* srcEnd = frameBuffer + frameBufferSize;

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -236,7 +236,12 @@ class GfxRenderer {
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer(bool turnOffScreen = false) const;
   bool storeBwBuffer();    // Returns true if buffer was stored successfully
-  void restoreBwBuffer();  // Restore and free the stored buffer
+  void restoreBwBuffer();  // Restore the stored buffer (does NOT free it)
+  // True if a compressed BW backup is currently held (either from a prior
+  // storeBwBuffer() that hasn't been freed yet, or from another caller's
+  // store path leaving its backup around). Callers can use this to decide
+  // whether restoreBwBuffer() will produce useful framebuffer content.
+  bool hasStoredBwBuffer() const { return bwCompressedBackup != nullptr; }
   void cleanupGrayscaleWithFrameBuffer() const;
 
   // Font helpers

--- a/lib/hal/BluetoothHIDManager.cpp
+++ b/lib/hal/BluetoothHIDManager.cpp
@@ -231,6 +231,43 @@ bool BluetoothHIDManager::enable() {
   return true;
 }
 
+bool BluetoothHIDManager::tryEnableIfRequested() {
+  if (!_enableLaterRequested) return false;
+  _enableLaterRequested = false;
+  if (_enabled) return false;  // someone else already brought it back up
+
+  if (!enable()) {
+    LOG_ERR("BT", "tryEnableIfRequested: enable() failed (%s)", lastError.c_str());
+    return false;
+  }
+
+  // checkAutoReconnect() gates on a local button press because in its usual
+  // "remote got out of range / disconnected on its own" scenario the
+  // firmware can't tell whether the user is actively reading or has set
+  // the device down. But this drain path runs after a programmatic
+  // disable() that the user didn't ask for (we dropped BLE around a
+  // heap-heavy re-layout). They expect the remote to resume without
+  // having to wake the reconnect logic with a local button mash, so do
+  // the connect ourselves the same way the reader-menu's manual
+  // "Reconnect bonded" entry would. _bondedDeviceAddress survives the
+  // disable()/enable() cycle (just a std::string on the singleton; we
+  // don't clear it in disable()), so it's still valid here.
+  if (_bondedDeviceAddress.empty()) {
+    LOG_DBG("BT", "tryEnableIfRequested: no bonded device cached; nothing to reconnect");
+    return true;
+  }
+  LOG_INF("BT", "tryEnableIfRequested: reconnecting to bonded device %s", _bondedDeviceAddress.c_str());
+  if (!connectToDevice(_bondedDeviceAddress)) {
+    // Not fatal — the remote might be powered off or out of range. The
+    // user can still hit a local button later to trigger
+    // checkAutoReconnect()'s retry path, or pop into the BT settings
+    // menu and tap Reconnect manually.
+    LOG_INF("BT", "tryEnableIfRequested: bonded reconnect failed (%s); falling back to user-input retry",
+            lastError.c_str());
+  }
+  return true;
+}
+
 bool BluetoothHIDManager::disable() {
   if (!_enabled) {
     LOG_DBG("BT", "Already disabled");

--- a/lib/hal/BluetoothHIDManager.h
+++ b/lib/hal/BluetoothHIDManager.h
@@ -76,6 +76,20 @@ public:
     return disable();
   }
 
+  // Deferred enable. Paired with requestDisableLater() for the case where we
+  // temporarily drop BLE around a heap-heavy operation (full chapter
+  // re-layout under font/margin change) and want it back online afterward.
+  //
+  // Drain in the main loop after the heavy operation completes. The drain
+  // re-enables the stack AND triggers a reconnect to the saved bonded
+  // remote (using SETTINGS.bleBondedDeviceAddr — the runtime
+  // _bondedDeviceAddress is not restored across deinit/init), so the user
+  // doesn't have to press a local button to wake checkAutoReconnect. NimBLE
+  // init plus connect can block ~2-3 s; safe to call from main loop
+  // outside any RenderLock.
+  void requestEnableLater() { _enableLaterRequested = true; }
+  bool tryEnableIfRequested();
+
   // Scanning
   void startScan(uint32_t durationMs = 10000);
   void stopScan();
@@ -129,6 +143,7 @@ private:
 
   bool _enabled = false;
   bool _disableLaterRequested = false;
+  bool _enableLaterRequested = false;
   bool _scanning = false;
   std::vector<BluetoothDevice> _discoveredDevices;
   std::vector<ConnectedDevice> _connectedDevices;

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -243,9 +243,11 @@ class CrossPointSettings {
   // Sleep screen cover filter
   uint8_t sleepScreenCoverFilter = NO_FILTER;
   // While asleep, a brief tap on the power button cycles to a new random
-  // image from /.sleep instead of waking the device. Off by default — every
-  // cycle costs a boot + e-ink refresh worth of battery.
-  uint8_t cycleScreensaverOnTap = 0;
+  // image from /.sleep instead of waking the device. On by default in
+  // CrumBLE — the cycling sleep screen is one of our headline features
+  // and the battery cost (one boot + e-ink half-refresh per cycle) is
+  // small enough that opt-out is the right default for new users.
+  uint8_t cycleScreensaverOnTap = 1;
   // Status bar settings (statusBar retained for migration only)
   uint8_t statusBar = FULL;
   uint8_t statusBarChapterPageCount = 1;
@@ -307,8 +309,11 @@ class CrossPointSettings {
   uint8_t hideBatteryPercentage = HIDE_NEVER;
   // Long-press page turn button behavior
   uint8_t longPressButtonBehavior = OFF;
-  // UI Theme
-  uint8_t uiTheme = LYRA;
+  // UI Theme. CrumBLE defaults to LYRA_FLOW (3D-perspective book carousel
+  // from CrossInk Carousel) — it's the visual centerpiece of the fork
+  // and what most users will want first. Anyone preferring the simpler
+  // Lyra list can switch in Settings -> Display -> UI Theme.
+  uint8_t uiTheme = LYRA_FLOW;
   // Recent Books screen layout
   uint8_t recentBooksView = RECENT_BOOKS_LIST;
   // Sunlight fading compensation

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -1028,6 +1028,19 @@ void HomeActivity::showHomeBookActionMenu(const std::string& bookPath) {
               if (selectorIndex >= recentBooks.size() + 1) {
                 selectorIndex = recentBooks.empty() ? 0 : static_cast<int>(recentBooks.size()) - 1;
               }
+              // The removed book just disappeared from the recent list, but
+              // the Flow carousel paints from `carouselFrames` (cached
+              // pre-rasterized covers) and the Lyra shelf from
+              // `shelfSnapshot` — neither of which knows the book set
+              // changed. Without invalidation, the next paint replayed the
+              // stale snapshot showing the removed cover until the user
+              // moved the selector, which finally forced a re-layout. Flush
+              // every relevant cache so the removal is visible immediately.
+              carouselFramesReady = false;
+              shelfCoversLoaded = false;
+              invalidateShelfPathsCache();
+              shelfSnapshotValid = false;
+              lastRenderedCoverSelectorValid = false;
             }
             requestUpdate();
             return;

--- a/src/activities/reader/BookSettingsDrawerActivity.cpp
+++ b/src/activities/reader/BookSettingsDrawerActivity.cpp
@@ -95,15 +95,30 @@ void BookSettingsDrawerActivity::buildItems() {
   items.clear();
 
   // 1) Pull every Reader-category non-Action setting, in declaration order.
+  //
+  // `getSettingsList()` returns std::vector<SettingInfo> BY VALUE. The
+  // returned vector is a temporary that lives only for the duration of this
+  // range-for loop; any pointer captured into `info` becomes dangling once
+  // the loop exits. We used to do `infoPtr = &info` and bake that pointer
+  // into the lambda closures stored on each Item — which "worked" right
+  // after onEnter (the freed bytes were still intact) but broke after the
+  // next allocation overwrote them. Loading a new font in particular
+  // triggered enough heap churn that the SettingInfos for items right after
+  // Font (Line Spacing, Orientation) got clobbered first; their enumValues
+  // vector read as garbage and I18N.get(garbage_id) rendered as "????".
+  //
+  // Fix: copy SettingInfo by value into each lambda's closure. The
+  // valuePtr / valueGetter / enumValues members are all owned-by-value, so
+  // the copy stays valid as long as the lambda lives. SETTINGS itself is a
+  // global, and the pointer-to-member in valuePtr is stable regardless of
+  // where the SettingInfo copy lives.
   for (const auto& info : getSettingsList()) {
     if (info.category != StrId::STR_CAT_READER) continue;
     if (info.type == SettingType::ACTION || info.type == SettingType::SECTION_HEADER) continue;
     Item item;
     item.nameId = info.nameId;
-    item.settingInfo = &info;
-    const SettingInfo* infoPtr = &info;
-    item.getValueText = [infoPtr]() { return valueTextForSetting(*infoPtr); };
-    item.change = [infoPtr](int delta) { applyDeltaToSetting(*infoPtr, delta); };
+    item.getValueText = [infoCopy = info]() { return valueTextForSetting(infoCopy); };
+    item.change = [infoCopy = info](int delta) { applyDeltaToSetting(infoCopy, delta); };
     items.push_back(std::move(item));
   }
 

--- a/src/activities/reader/BookSettingsDrawerActivity.cpp
+++ b/src/activities/reader/BookSettingsDrawerActivity.cpp
@@ -71,10 +71,14 @@ void BookSettingsDrawerActivity::onEnter() {
   Activity::onEnter();
 
   // Cache the underlying reader page so we can preserve it through every
-  // partial-refresh redraw without re-rendering the EPUB.
+  // partial-refresh redraw without re-rendering the EPUB. If the malloc
+  // for the compressed backup fails (heap fragmentation under BLE
+  // pressure is the usual cause), renderDrawer() falls back to either
+  // the reader's existing backup or to whatever's already in the
+  // framebuffer — both better than painting onto a cleared screen.
   readerBufferStored = renderer.storeBwBuffer();
   if (!readerBufferStored) {
-    LOG_ERR("BSD", "Failed to store reader page buffer; drawer will paint over a cleared screen");
+    LOG_INF("BSD", "Failed to snapshot reader page; drawer will fall back to existing BW backup or in-place framebuffer");
   }
 
   buildItems();
@@ -294,11 +298,26 @@ void BookSettingsDrawerActivity::loop() {
 
 void BookSettingsDrawerActivity::renderDrawer() {
   // Repaint reader page underneath, then draw the drawer panel on top.
+  //
+  // Three tiers of fallback for getting the reader page into the
+  // framebuffer:
+  //   1. Our own storeBwBuffer() snapshot from onEnter, if it succeeded.
+  //   2. Otherwise, whatever backup the renderer already had — the
+  //      EpubReader stores its own BW backup at the end of each page
+  //      render (for the grayscale pass) and doesn't free it after
+  //      restoring, so it usually sits there waiting for us.
+  //   3. Last resort: do NOT clear the screen. Whatever was last
+  //      rendered is what the e-ink is currently showing; clearing would
+  //      diff every reader-page pixel against white on the next fast
+  //      refresh and paint the panel onto a stark white background.
+  //      Leaving the framebuffer alone matches whatever's already on
+  //      the display so the fast-refresh diff is small.
   if (readerBufferStored) {
     renderer.restoreBwBuffer();
-  } else {
-    renderer.clearScreen();
+  } else if (renderer.hasStoredBwBuffer()) {
+    renderer.restoreBwBuffer();
   }
+  // else: intentionally no clearScreen() — see comment above.
 
   // Panel body — filled white, with the top two corners rounded so the panel
   // looks like it has rounded shoulders.

--- a/src/activities/reader/BookSettingsDrawerActivity.h
+++ b/src/activities/reader/BookSettingsDrawerActivity.h
@@ -33,12 +33,12 @@ class BookSettingsDrawerActivity final : public Activity {
 
  private:
   // A single row in the drawer.
-  //   - Setting-bound rows wrap a SettingInfo for value-getter/toggler.
-  //   - The two BLE rows are special and use the activate callback.
+  //   - Setting-bound rows have non-null change/getValueText callbacks; each
+  //     closure carries its own SettingInfo copy (see buildItems for why).
+  //   - The BLE quick-action rows are special and use the activate callback.
   struct Item {
     StrId nameId;
     bool isAction = false;            // true: Confirm activates; false: Confirm toggles/cycles value
-    const SettingInfo* settingInfo = nullptr;  // non-null for setting-bound rows
     std::function<std::string()> getValueText;
     std::function<void(int delta)> change;
     std::function<void()> activate;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1119,6 +1119,14 @@ void EpubReaderActivity::executeReaderQuickAction(CrossPointSettings::LONG_PRESS
                                // doesn't trigger a wasteful section rebuild.
                                const auto* menu = std::get_if<MenuResult>(&result.data);
                                if (menu && menu->settingsChanged) {
+                                 // BLE handling for the re-layout is centralized in render()'s
+                                 // cache-miss path (search for "Cache miss with BLE up"). We
+                                 // don't drop BLE here because (a) inline disable() can
+                                 // deadlock against NimBLE's host task if the remote is
+                                 // actively sending events, and (b) the drawer is just one of
+                                 // many section.reset() call sites — chapter boundaries hit
+                                 // the same problem. Centralizing in render() handles all of
+                                 // them uniformly.
                                  RenderLock lock(*this);
                                  if (section) {
                                    cachedSpineIndex = currentSpineIndex;
@@ -1491,6 +1499,38 @@ void EpubReaderActivity::render(RenderLock&& lock) {
                                   SETTINGS.paragraphAlignment, viewportWidth, viewportHeight,
                                   SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle, SETTINGS.imageRendering,
                                   SETTINGS.bionicReadingEnabled, SETTINGS.guideReadingEnabled)) {
+      // Cache miss with BLE up: NimBLE's ~58 KB share has historically
+      // made the parser either return layoutAbortedForLowMemory (good —
+      // the reactive retry path below handles it) or simply hang
+      // mid-page when the malloc pattern fragments badly (bad — watchdog
+      // territory). Drop BLE proactively and defer this build to the next
+      // render pass after the main loop's tryDisableIfRequested() drain
+      // runs. Cheaper than relying on the reactive retry, and works for
+      // *every* cache-miss trigger: font/margin/etc. changes from the
+      // drawer, chapter boundary advances, percent jumps, anything.
+      //
+      // We can't disable() inline here — we hold the RenderLock and
+      // NimBLE teardown can fire callbacks that call requestUpdateAndWait,
+      // which trips the lock-held assertion. Deferred + return is the
+      // safe pattern; the next render iteration finds BLE off and builds
+      // with full heap headroom. bleAutoReEnableAfterReindex brings it
+      // back online + reconnects to the bonded remote after the build.
+      auto& btMgr = BluetoothHIDManager::getInstance();
+      if (btMgr.isEnabled()) {
+        LOG_INF("ERS", "Cache miss with BLE up; dropping BLE and deferring build to next render");
+        btMgr.requestDisableLater();
+        bleAutoReEnableAfterReindex = true;
+        // Reset section back to null. We constructed it above (line ~1495)
+        // and loadSectionFile failed, so it's holding an empty Section
+        // shell. If we don't drop it, the next render iteration's
+        // `if (!section)` short-circuits and the render proceeds with a
+        // zero-page Section — user sees "empty chapter". Resetting ensures
+        // we re-enter the construct+build path next time around.
+        section.reset();
+        requestUpdate();
+        return;
+      }
+
       LOG_DBG("ERS", "Cache not found, building... (free=%u, maxAlloc=%u)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
 
       GUI.drawPopup(renderer, tr(STR_INDEXING));
@@ -1524,8 +1564,22 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           LOG_INF("ERS", "Layout aborted under BLE pressure; dropping BLE and retrying chapter load");
           layoutBleRetryAttempted = true;
           BluetoothHIDManager::getInstance().requestDisableLater();
+          // Same re-enable hook the drawer path uses — once this retry's
+          // section build succeeds, bring BLE back up so the bonded
+          // remote reconnects on the user's next press.
+          bleAutoReEnableAfterReindex = true;
           requestUpdate();
           return;
+        }
+        // Build failed and we already retried (or BLE wasn't the culprit).
+        // Bring BLE back up before bailing so the user doesn't lose their
+        // remote on top of the layout error — checkAutoReconnect() will
+        // resume the bonded link on the next button press once the stack
+        // is enabled again.
+        if (bleAutoReEnableAfterReindex) {
+          bleAutoReEnableAfterReindex = false;
+          LOG_INF("ERS", "Section build failed; requesting BLE re-enable so the remote isn't lost");
+          BluetoothHIDManager::getInstance().requestEnableLater();
         }
         if (layoutAbortedForLowMemory) {
           showLowMemoryLayoutError();
@@ -1539,6 +1593,17 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       // Section parsed successfully — clear the BLE-retry latch so a future
       // failure on a different chapter can also use the retry path.
       layoutBleRetryAttempted = false;
+      // If we dropped BLE around this build (drawer settings change, or the
+      // reactive retry path above), bring it back up now that the heap
+      // pressure is gone. requestEnableLater() defers to the main loop so
+      // NimBLE init doesn't fight the page render that's about to fire.
+      // Once re-enabled, checkAutoReconnect() resumes the bonded link on
+      // the user's next button press.
+      if (bleAutoReEnableAfterReindex) {
+        bleAutoReEnableAfterReindex = false;
+        LOG_INF("ERS", "Section build done; requesting BLE re-enable for bonded remote reconnect");
+        BluetoothHIDManager::getInstance().requestEnableLater();
+      }
 
       if (imagesWereSuppressed) {
         snprintf(APP_STATE.pendingAlertTitle, sizeof(APP_STATE.pendingAlertTitle), "%s",

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1533,9 +1533,35 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
       LOG_DBG("ERS", "Cache not found, building... (free=%u, maxAlloc=%u)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
 
-      GUI.drawPopup(renderer, tr(STR_INDEXING));
+      // Animated indexing popup. The parser ticks the callback every
+      // ~250 ms; we cycle the trailing dots so the user sees the system
+      // is alive during the multi-second chapter build instead of
+      // staring at a frozen popup.
+      //
+      // Pre-measure the widest frame ("Indexing...") and pass that as
+      // minTextWidth to every drawPopup call. The box sizes itself once
+      // off the widest frame and stays anchored on the same pixels for
+      // every subsequent tick — without this floor, period vs space
+      // glyph widths differ enough in Inter that the box visibly pulses
+      // wider on the 3-dot frame.
+      char widestBuf[40];
+      snprintf(widestBuf, sizeof(widestBuf), "%s...", tr(STR_INDEXING));
+      const int popupMinTextWidth =
+          renderer.getTextWidth(UI_12_FONT_ID, widestBuf, EpdFontFamily::BOLD);
 
-      const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
+      // Left-anchor the text so "Indexing" stays pinned at a fixed
+      // position and the trailing dots cycle to its right without
+      // visibly shifting the word.
+      GUI.drawPopup(renderer, tr(STR_INDEXING), popupMinTextWidth, /*leftAlignText=*/true);
+
+      const auto popupFn = [this, popupMinTextWidth]() {
+        static uint8_t dotPhase = 0;
+        static constexpr const char* kDots[4] = {"", ".", "..", "..."};
+        dotPhase = (dotPhase + 1) % 4;
+        char buf[40];
+        snprintf(buf, sizeof(buf), "%s%s", tr(STR_INDEXING), kDots[dotPhase]);
+        GUI.drawPopup(renderer, buf, popupMinTextWidth, /*leftAlignText=*/true);
+      };
 
       bool imagesWereSuppressed = false;
       bool layoutAbortedForLowMemory = false;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -62,10 +62,16 @@ class EpubReaderActivity final : public Activity {
   int pageLoadRetryCount = 0;
   // CrumBLE: if a chapter layout aborts under heap pressure and BLE is
   // currently consuming its ~58 KB share, retry the layout once with BLE
-  // disabled (NimBLE will auto-reconnect to the bonded remote on the user's
-  // next button press). Flag gates the retry so we don't loop forever if
-  // the chapter genuinely can't be parsed.
+  // disabled. Flag gates the retry so we don't loop forever if the
+  // chapter genuinely can't be parsed.
   bool layoutBleRetryAttempted = false;
+  // CrumBLE: when we proactively drop BLE around a heavy re-layout (drawer
+  // settings change, or the reactive chapter-abort retry), set this so the
+  // next successful section build re-enables BLE via requestEnableLater().
+  // Without this, the user is stuck without their remote until they go to
+  // Reader Menu -> Bluetooth to re-enable manually — checkAutoReconnect()
+  // refuses to do anything while _enabled is false.
+  bool bleAutoReEnableAfterReindex = false;
   enum class BookmarkFeedbackType : uint8_t {
     Added,
     Removed,

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -655,11 +655,15 @@ void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
-Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {
+Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message, int minTextWidth,
+                          bool leftAlignText) const {
   constexpr int margin = 15;
   // Scale y position proportionally to screen height (7.5% from top)
   const int y = static_cast<int>(renderer.getScreenHeight() * 0.075f);
-  const int textWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::BOLD);
+  const int actualTextWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::BOLD);
+  // Use minTextWidth as a floor so animated popups (e.g. cycling
+  // "Indexing." / ".." / "...") keep a stable box width across frames.
+  const int textWidth = std::max(actualTextWidth, minTextWidth);
   const int textHeight = renderer.getLineHeight(UI_12_FONT_ID);
   const int w = textWidth + margin * 2;
   const int h = textHeight + margin * 2;
@@ -668,7 +672,11 @@ Rect BaseTheme::drawPopup(const GfxRenderer& renderer, const char* message) cons
   renderer.fillRect(x - 2, y - 2, w + 4, h + 4, true);  // frame thickness 2
   renderer.fillRect(x, y, w, h, false);
 
-  const int textX = x + (w - textWidth) / 2;
+  // Center-align the actual text in the (possibly wider) box, OR
+  // left-anchor it at the margin if the caller asked for left alignment
+  // (used by dots-style animations where the leading word should stay
+  // pinned and only the trailing dots shift).
+  const int textX = leftAlignText ? (x + margin) : (x + (w - actualTextWidth) / 2);
   const int textY = y + margin - 2;
   renderer.drawText(UI_12_FONT_ID, textX, textY, message, true, EpdFontFamily::BOLD);
   renderer.displayBuffer();

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -169,7 +169,22 @@ class BaseTheme {
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                               const std::function<std::string(int index)>& buttonLabel,
                               const std::function<UIIcon(int index)>& rowIcon) const;
-  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
+  // minTextWidth: when > 0, sizes the popup box for at least this much
+  // text width regardless of the actual message length. Used by animated
+  // popups (e.g. "Indexing", "Indexing.", "Indexing..", "Indexing...")
+  // that want a stable box size across frames so the box doesn't pulse
+  // wider/narrower as the trailing dots are added or removed. Pass the
+  // widest reference message's getTextWidth() result.
+  //
+  // leftAlignText: when true, anchors the text at the left margin of the
+  // box rather than centering it. Only meaningful with minTextWidth set
+  // (otherwise the box exactly fits the text and both alignments
+  // produce the same result). For animated dots-style indicators, this
+  // keeps the leading word ("Indexing") pinned to a fixed position so
+  // the trailing dots appear/disappear to its right without shifting
+  // the word itself.
+  virtual Rect drawPopup(const GfxRenderer& renderer, const char* message, int minTextWidth = 0,
+                         bool leftAlignText = false) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
   virtual void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                              const int pageCount, std::string title, const int paddingBottom = 0,

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -678,11 +678,15 @@ void LyraTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
   }
 }
 
-Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message) const {
+Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message, int minTextWidth,
+                          bool leftAlignText) const {
   // Scale y position proportionally to screen height (16.5% from top)
   const int y = static_cast<int>(renderer.getScreenHeight() * 0.165f);
   constexpr int outline = 2;
-  const int textWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::REGULAR);
+  const int actualTextWidth = renderer.getTextWidth(UI_12_FONT_ID, message, EpdFontFamily::REGULAR);
+  // minTextWidth floors the box width for stable animated popups (see
+  // BaseTheme::drawPopup for the rationale).
+  const int textWidth = std::max(actualTextWidth, minTextWidth);
   const int textHeight = renderer.getLineHeight(UI_12_FONT_ID);
   const int w = textWidth + popupMarginX * 2;
   const int h = textHeight + popupMarginY * 2;
@@ -692,7 +696,9 @@ Rect LyraTheme::drawPopup(const GfxRenderer& renderer, const char* message) cons
                            Color::White);
   renderer.fillRoundedRect(x, y, w, h, cornerRadius, Color::Black);
 
-  const int textX = x + (w - textWidth) / 2;
+  // Center-align in the (possibly wider) box, OR left-anchor at the
+  // margin for dots-style animations that want the leading word pinned.
+  const int textX = leftAlignText ? (x + popupMarginX) : (x + (w - actualTextWidth) / 2);
   const int textY = y + popupMarginY - 2;
   renderer.drawText(UI_12_FONT_ID, textX, textY, message, false, EpdFontFamily::REGULAR);
   renderer.displayBuffer();

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -74,7 +74,8 @@ class LyraTheme : public BaseTheme {
                            const std::function<bool()>& storeCoverBuffer, const BookReadingStats* stats = nullptr,
                            float progressPercent = -1.0f) const override;
   void drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) const;
-  Rect drawPopup(const GfxRenderer& renderer, const char* message) const override;
+  Rect drawPopup(const GfxRenderer& renderer, const char* message, int minTextWidth = 0,
+                 bool leftAlignText = false) const override;
   void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const override;
   bool showsFileIcons() const override { return true; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -872,6 +872,11 @@ void loop() {
   // the render lock during the transition; doing it here, after loop()
   // returns, is safe.
   btMgr.tryDisableIfRequested();
+  // Companion drain: when the reader proactively drops BLE around a heavy
+  // re-layout (e.g. font change from the Book Settings drawer), it asks
+  // for BLE to come back up once the indexer finishes. checkAutoReconnect
+  // then resumes the bonded-device link on the user's next button press.
+  btMgr.tryEnableIfRequested();
   const bool bleRecentActivity = btMgr.hasRecentActivity();
 
   renderer.setFadingFix(SETTINGS.fadingFix);


### PR DESCRIPTION
## Summary
Bug-fix bundle from device testing, plus two default changes:

- **Drawer "????" fix** — BookSettingsDrawer captured pointers into a temporary `getSettingsList()` vector; they dangled after the loop and got clobbered (most reliably by a font change's heap churn), rendering Line Spacing / Orientation values as "????". Now captures `SettingInfo` by value.
- **Carousel stale cover** — "Remove from Recent Books" didn't invalidate the cached carousel/shelf frames, so the removed cover lingered until the next selector move. Now flushes all cache flags.
- **Drawer white screen** — `storeBwBuffer()` freed the existing backup before a (failable) malloc; under BLE heap pressure the drawer fell back to `clearScreen()`. Now allocates-first and the drawer tiers fallbacks (own snapshot → reader's backup → leave framebuffer).
- **BLE drop/reconnect around re-layouts** — centralized in render()'s cache-miss path: drop BLE before any heavy section build (font change, chapter boundary, etc.), then re-enable + reconnect to the bonded remote after. Fixes the indexing hang with BLE active.
- **Indexing popup animation** — parser ticks the popup every ~250 ms; cycling dots with a stable, left-anchored box. Plus `yield()` per parse chunk (fixes watchdog/starvation hangs on heavy chapters and rapid-Back spam).
- **Defaults**: UI theme → Flow, Tap-Power-While-Asleep-to-Cycle → on (first-boot only).

## Test plan
- [x] Drawer font change keeps Line Spacing / Orientation labels
- [x] Remove from Recent updates carousel immediately
- [x] Drawer shows reader page behind it (not white)
- [x] BLE drops for indexing then auto-reconnects
- [x] Chapter-back + rapid-Back no longer hang
- [x] Indexing popup animates with stable box