### PR TITLE
v3.0.1 — carousel crash + cover/sleep fixes + X3 sim tooling

### DIFF
--- a/X3_SUPPORT.md
+++ b/X3_SUPPORT.md
@@ -1,0 +1,55 @@
+# X3 support — readiness audit (branch: feat/x3-support)
+
+Goal for this pass: **boot + usable on the Xteink X3**, with **no X3 on hand to test**.
+
+## TL;DR
+CrumBLE v3.0.0 is **already runtime-capable on the X3** — the existing
+`crumble-firmware.bin` IS the X3 binary (one firmware, device detected at boot).
+No separate build, and the audit below found **no X3 crash/boot risks in our
+additions**. The remaining gaps are **cosmetic** (Flow theme proportions tuned
+for the X4) and need a real X3 to tune. So this branch is an audit + validation
+plan, not code changes — making speculative layout edits without an X3 would
+risk the tested X4 build for no verifiable gain.
+
+## What's already handled (CrossInk 1.3 base + our dynamic sizing)
+- **Device detection:** `HalGPIO::detectDeviceTypeWithFingerprint()` at boot →
+  `gpio.deviceIsX3()`. Single binary, runtime-selected.
+- **Display:** SDK `setDisplayX3()` (792×528 vs X4 800×480), X3 refresh handling,
+  X3 initial-full-sync. Framebuffers are `frameBuffer0/1[MAX_BUFFER_SIZE]`
+  (52272 = max of both), so the X3's larger buffer fits — no overflow.
+- **Flash/partition:** both target 16 MB; the v3.0.0 7.5 MB app slots fit the X3.
+- **Hardware:** X3 IMU (QMI8658 tilt-turn) + DS3231 RTC clock are gated on
+  `deviceIsX3()` and handled by the 1.3 base.
+- **CrossInk themes** (Classic/Lyra) already adapt to X3 layout.
+
+## Audit of OUR additions (no X3-breaking assumptions found)
+- No hardcoded `48000` / framebuffer sizes anywhere in `src/` or our libs.
+- `storeCoverBuffer()` allocates via `renderer.getBufferSize()` (dynamic) and
+  `saveSleepFrameBuffer()`/`loadSleepFrameBuffer()` use the live buffer size.
+- `LyraFlowTheme` lays out from `renderer.getScreenWidth()/getScreenHeight()`.
+- BLE, Collections, Series, sleep-cycling, reader: all device-agnostic.
+
+## Known COSMETIC gaps (out of scope here; need a real X3 to tune)
+- **Flow shelf grid** (`LyraFlowTheme.cpp` ~448): fixed `kCellWidth=100`,
+  `kCellGap=16`, `kSidePad=16` sized for "480 exactly" → on X3's 528-wide
+  portrait the row sits with ~48 px extra (centered or right-margin depending
+  on positioning). Renders + navigable, just not full-width.
+- **Carousel cover sizes** (`kCenterThumbW/H`, side covers): X4-tuned; fine on
+  X3 (smaller than screen) but not proportioned for it.
+- **Default theme is LYRA_FLOW** (X4-tuned). A fresh X3 boots into Flow. Option:
+  default X3 to an X3-aware theme (Lyra) — small, low-risk behavior change for
+  X3 only, but it's a product call (and still unverified without hardware).
+
+## Validation checklist (run on a real X3 before claiming support)
+1. Boots; serial shows `Hardware detect: X3`; no panic.
+2. Reader renders text correctly at 792×528 (the core function).
+3. Flow home: carousel + shelf navigable; covers generate (Recent + Collections).
+4. BLE pair + page-turn; Collections create/add/remove; series stacking.
+5. Sleep-screen cycle + PNG; QuickResume.
+6. X3-specific: IMU tilt-turn, RTC clock in status bar, recovery-mode key combo.
+7. Watch heap on X3 (framebuffer is ~4 KB larger than X4) under BLE + image pages.
+
+## Recommended next steps
+1. Get the existing `crumble-firmware.bin` onto a real X3 and run the checklist.
+2. If it boots + reads, ship "X3 supported (Flow layout is X4-tuned; polish WIP)".
+3. Then tune the Flow shelf grid / cover sizes for 792×528 (the "full polish" pass).

--- a/X3_SUPPORT.md
+++ b/X3_SUPPORT.md
@@ -6,10 +6,13 @@ Goal for this pass: **boot + usable on the Xteink X3**, with **no X3 on hand to 
 CrumBLE v3.0.0 is **already runtime-capable on the X3** — the existing
 `crumble-firmware.bin` IS the X3 binary (one firmware, device detected at boot).
 No separate build, and the audit below found **no X3 crash/boot risks in our
-additions**. The remaining gaps are **cosmetic** (Flow theme proportions tuned
-for the X4) and need a real X3 to tune. So this branch is an audit + validation
-plan, not code changes — making speculative layout edits without an X3 would
-risk the tested X4 build for no verifiable gain.
+additions**. The Flow layout was a suspected cosmetic gap; it has now been
+**verified correct on the X3 panel in the simulator** (see "Simulator
+validation" below) — the shelf/carousel are adaptive and render consistently
+with the X4, so no layout code changes were needed. The only firmware changes on
+this branch are **test-tooling**; remaining unknowns are **hardware-only**
+behaviors (IMU/RTC, real e-ink refresh, heap under BLE) that still need a real
+X3.
 
 ## What's already handled (CrossInk 1.3 base + our dynamic sizing)
 - **Device detection:** `HalGPIO::detectDeviceTypeWithFingerprint()` at boot →
@@ -29,16 +32,33 @@ risk the tested X4 build for no verifiable gain.
 - `LyraFlowTheme` lays out from `renderer.getScreenWidth()/getScreenHeight()`.
 - BLE, Collections, Series, sleep-cycling, reader: all device-agnostic.
 
-## Known COSMETIC gaps (out of scope here; need a real X3 to tune)
-- **Flow shelf grid** (`LyraFlowTheme.cpp` ~448): fixed `kCellWidth=100`,
-  `kCellGap=16`, `kSidePad=16` sized for "480 exactly" → on X3's 528-wide
-  portrait the row sits with ~48 px extra (centered or right-margin depending
-  on positioning). Renders + navigable, just not full-width.
-- **Carousel cover sizes** (`kCenterThumbW/H`, side covers): X4-tuned; fine on
-  X3 (smaller than screen) but not proportioned for it.
-- **Default theme is LYRA_FLOW** (X4-tuned). A fresh X3 boots into Flow. Option:
-  default X3 to an X3-aware theme (Lyra) — small, low-risk behavior change for
-  X3 only, but it's a product call (and still unverified without hardware).
+## Simulator validation (this branch)
+The simulator now builds the X3 panel, so the Flow layout could be eyeballed at
+792×528 without hardware:
+- **Two sim envs:** `[env:simulator]` (X4, 800×480) and `[env:simulator_x3]`
+  (X3, 792×528) extend a shared `[simulator_base]`. Build either with
+  `pio run -e simulator{_x3}` or `scripts/run_simulator_smoke_test.py --device x4|x3`.
+- **Headless smoke test** (`SimulatorSmokeTest.cpp`) walks Home → File Browser →
+  Recent Books → Settings → Reader Options → Reader Menu → Sleep → Reader (with
+  page-turn/menu/options input) → **populated Home**, dumping each screen to a
+  24-bit BMP when `CROSSINK_SIMULATOR_DUMP_DIR` is set. Passes on both panels.
+- **Multi-cover shelf:** `--shelf` synthesizes 6 cover-bearing EPUBs (reusing the
+  JPEG fixture's images) and seeds a `Favorites` collection, so the densest
+  layout — the cover grid — renders real thumbnails.
+
+**Result:** every screen fits 792×528 with no clipping; the populated Flow
+shelf/carousel renders real covers and is **visually consistent with the X4**.
+The grid is genuinely adaptive (`LyraFlowTheme.cpp` derives `visibleCells` from
+`rect.width` and centers via `rowStartX`); the X3's extra ~48 px portrait width
+is absorbed as margin/peek, not clipping. **No layout code changes were needed.**
+
+## Remaining unknowns (hardware-only; sim can't cover these)
+- **Carousel/cover proportions** look correct in the sim, but final "feel" on a
+  real X3 e-ink panel (contrast, ghosting, refresh) is unverified.
+- **Default theme is LYRA_FLOW.** A fresh X3 boots into Flow; the sim shows it
+  renders fine, so defaulting X3 to another theme is now optional, not a fix.
+- **Heap under load** (framebuffer ~4 KB larger than X4) during BLE + image pages
+  is a runtime-memory question the native sim (1 MB "heap") can't represent.
 
 ## Validation checklist (run on a real X3 before claiming support)
 1. Boots; serial shows `Hardware detect: X3`; no panic.
@@ -51,5 +71,7 @@ risk the tested X4 build for no verifiable gain.
 
 ## Recommended next steps
 1. Get the existing `crumble-firmware.bin` onto a real X3 and run the checklist.
-2. If it boots + reads, ship "X3 supported (Flow layout is X4-tuned; polish WIP)".
-3. Then tune the Flow shelf grid / cover sizes for 792×528 (the "full polish" pass).
+2. If it boots + reads, ship "X3 supported" — the Flow layout is sim-verified at
+   792×528, so the earlier "polish WIP" caveat no longer applies.
+3. Before merging this branch to main, the sim defaults to X4 (`[env:simulator]`);
+   use `--device x3` for X3 dumps. Keep the X4/X3 env split.

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,17 @@ crossink_version = 1.3.0
 ;         size selection, QuickResume, Minimal sleep, OPDS low-mem, etc.) with
 ;         CrumBLE's features (BLE page-turner, Collections, Flow theme,
 ;         AA-under-BLE, sleep cycling, large-library indexing) replayed on top.
-crumble_version = 3.0.0
+; v3.0.1: home/carousel stability + sleep fixes. Fixes a Lyra Carousel crash
+;         (onEnter rendered carousel frames without the render lock, racing the
+;         render task -> heap corruption -> xTaskPriorityDisinherit). Fixes a
+;         carousel-only stuck placeholder cover (invalid/corrupt thumbs are now
+;         revalidated + regenerated) and gives cover decode more heap headroom.
+;         Adds a static "Loading" during the first carousel warmup instead of a
+;         frozen-looking screen. Transparent-PNG sleep screens no longer pull
+;         the last book page in as a background unless you slept from a book.
+;         Also adds X4/X3 simulator envs + tooling (dev-only; X3 runtime support
+;         already shipped in 3.0.0).
+crumble_version = 3.0.1
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -196,7 +196,11 @@ build_flags =
   -DOMIT_HUGE_FONT
   -DOMIT_XLARGE_FONT
 
-[env:simulator]
+; Shared simulator config. Two concrete envs extend it: `simulator` (X4,
+; 800x480 — the default panel) and `simulator_x3` (X3, 792x528). Build either
+; with `pio run -e simulator` / `-e simulator_x3`, or via
+; scripts/run_simulator_smoke_test.py --device x4|x3.
+[simulator_base]
 platform = native
 custom_run_simulator_target_owner = project
 lib_compat_mode = off
@@ -228,7 +232,6 @@ build_flags =
   -DPNG_MAX_BUFFERED_PIXELS=16416
   -DDISABLE_FS_H_WARNING=1
   -DDESTRUCTOR_CLOSES_FILE=1
-  -DSIMULATOR_DEVICE_X3 ; simulate X3 panel (792x528) — feat/x3-support branch
   -Isrc
   -Isrc/simulator/sim_stubs ; native no-op stubs for ESP32-only HAL (BluetoothHIDManager)
   ;-DOMIT_EMOJI_FONTS ; uncomment to omit emoji/symbols glyphs from reading fonts
@@ -253,3 +256,16 @@ lib_deps =
   bitbank2/PNGdec @ ^1.0.0
   https://github.com/bitbank2/JPEGDEC.git#86282979224c8a32fd51e091ed5a35b0c699a52b
   links2004/WebSockets @ 2.7.3
+
+; X4 panel (800x480) — the default simulator target. No device flag needed;
+; the simulator package defaults to the X4 framebuffer shape.
+[env:simulator]
+extends = simulator_base
+
+; X3 panel (792x528). -DSIMULATOR_DEVICE_X3 switches the simulator framebuffer
+; to 792x528, makes gpio.deviceIsX3() report true, and exposes the tilt sensor.
+[env:simulator_x3]
+extends = simulator_base
+build_flags =
+  ${simulator_base.build_flags}
+  -DSIMULATOR_DEVICE_X3

--- a/platformio.ini
+++ b/platformio.ini
@@ -208,6 +208,7 @@ build_src_filter =
   -<network/OtaUpdater.cpp>
   -<network/WebDAVHandler.cpp>
   -<platform/skip_efuse_blk_check.c>
+  -<activities/settings/BluetoothSettingsActivity.cpp> ; NimBLE pairing UI — guarded out of the sim (see #ifndef SIMULATOR sites)
 build_flags =
   -std=gnu++2a
   !sdl2-config --cflags --libs
@@ -227,8 +228,9 @@ build_flags =
   -DPNG_MAX_BUFFERED_PIXELS=16416
   -DDISABLE_FS_H_WARNING=1
   -DDESTRUCTOR_CLOSES_FILE=1
-  ;-DSIMULATOR_DEVICE_X3 ; uncomment to simulate X3 screen size
+  -DSIMULATOR_DEVICE_X3 ; simulate X3 panel (792x528) — feat/x3-support branch
   -Isrc
+  -Isrc/simulator/sim_stubs ; native no-op stubs for ESP32-only HAL (BluetoothHIDManager)
   ;-DOMIT_EMOJI_FONTS ; uncomment to omit emoji/symbols glyphs from reading fonts
   ;-DOMIT_TEENSY_FONT ; uncomment to omit teensy (8px) font size
   ;-DOMIT_TINY_FONT ; uncomment to omit tiny (10px) font size

--- a/scripts/run_simulator_smoke_test.py
+++ b/scripts/run_simulator_smoke_test.py
@@ -13,8 +13,24 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PROGRAM = ROOT / ".pio" / "build" / "simulator" / "program"
+DEVICE_ENVS = {"x4": "simulator", "x3": "simulator_x3"}
 DEFAULT_BOOK = ROOT / "test" / "epubs" / "test_reader_rendering_matrix.epub"
+JPEG_FIXTURE = ROOT / "test" / "epubs" / "test_jpeg_images.epub"
+# Distinct cover sources (extracted from the JPEG fixture) paired with book
+# titles. Used by --shelf to synthesize a populated Favorites collection so the
+# multi-cover shelf grid can be eyeballed (X4 vs X3).
+SHELF_COVERS = [
+    ("Aurora Drift", "OEBPS/images/gradient_test.jpg"),
+    ("Bramble Hollow", "OEBPS/images/centering_test.jpg"),
+    ("Cobalt Reverie", "OEBPS/images/grayscale_test.jpg"),
+    ("Dune Cipher", "OEBPS/images/cache_test_1.jpg"),
+    ("Ember Atlas", "OEBPS/images/cache_test_2.jpg"),
+    ("Frost Lantern", "OEBPS/images/jpeg_format.jpg"),
+]
+
+
+def program_path(pio_env: str) -> Path:
+    return ROOT / ".pio" / "build" / pio_env / "program"
 CRASH_PATTERNS = (
     "std::bad_alloc",
     "terminating due to uncaught exception",
@@ -38,39 +54,139 @@ THEMES = {
 }
 
 
-def build_simulator() -> None:
-    print("Building simulator...", flush=True)
-    proc = subprocess.run(["pio", "run", "-e", "simulator"], cwd=ROOT)
+def build_simulator(pio_env: str) -> None:
+    print(f"Building simulator ({pio_env})...", flush=True)
+    proc = subprocess.run(["pio", "run", "-e", pio_env], cwd=ROOT)
     if proc.returncode != 0:
         raise SystemExit(proc.returncode)
 
 
-def prepare_fs(temp_root: Path, book: Path) -> str:
-    books_dir = temp_root / "fs_" / "books"
+def _slug(title: str) -> str:
+    return "".join(ch.lower() if ch.isalnum() else "_" for ch in title).strip("_")
+
+
+def make_cover_epub(dest_path: Path, title: str, cover_jpg: bytes) -> None:
+    """Write a minimal EPUB that declares `cover.jpg` as its cover (both the
+    EPUB2 <meta name="cover"> and EPUB3 properties="cover-image" forms, so the
+    ContentOpfParser finds it either way)."""
+    import zipfile
+
+    slug = _slug(title)
+    container = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n'
+        '  <rootfiles><rootfile full-path="OEBPS/content.opf" '
+        'media-type="application/oebps-package+xml"/></rootfiles>\n'
+        '</container>\n'
+    )
+    opf = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">\n'
+        '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n'
+        f'    <dc:identifier id="uid">cover-fixture-{slug}</dc:identifier>\n'
+        f'    <dc:title>{title}</dc:title>\n'
+        '    <dc:language>en</dc:language>\n'
+        '    <meta name="cover" content="cover-img"/>\n'
+        '  </metadata>\n'
+        '  <manifest>\n'
+        '    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>\n'
+        '    <item id="cover-img" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>\n'
+        '    <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>\n'
+        '  </manifest>\n'
+        '  <spine><itemref idref="chap1"/></spine>\n'
+        '</package>\n'
+    )
+    nav = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">\n'
+        '<head><title>nav</title></head><body>\n'
+        '<nav epub:type="toc"><ol><li><a href="chap1.xhtml">Chapter 1</a></li></ol></nav>\n'
+        '</body></html>\n'
+    )
+    chap = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<html xmlns="http://www.w3.org/1999/xhtml"><head><title>{title}</title></head><body>\n'
+        f'<h1>{title}</h1>\n<p>Synthetic shelf fixture for the cover grid layout check.</p>\n'
+        '</body></html>\n'
+    )
+    with zipfile.ZipFile(dest_path, "w", zipfile.ZIP_DEFLATED) as z:
+        # mimetype must be the first entry and stored uncompressed.
+        z.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        z.writestr("META-INF/container.xml", container)
+        z.writestr("OEBPS/content.opf", opf)
+        z.writestr("OEBPS/nav.xhtml", nav)
+        z.writestr("OEBPS/chap1.xhtml", chap)
+        z.writestr("OEBPS/cover.jpg", cover_jpg)
+
+
+def build_cover_fixtures(books_dir: Path) -> list[str]:
+    import zipfile
+
+    sim_paths: list[str] = []
+    with zipfile.ZipFile(JPEG_FIXTURE) as src:
+        for title, member in SHELF_COVERS:
+            cover = src.read(member)
+            name = f"{_slug(title)}.epub"
+            make_cover_epub(books_dir / name, title, cover)
+            sim_paths.append(f"/books/{name}")
+    return sim_paths
+
+
+def write_collections(crosspoint_dir: Path, book_paths: list[str]) -> None:
+    import json
+
+    crosspoint_dir.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "version": 1,
+        "active": "favorites",
+        "collections": [
+            {
+                "id": "favorites",
+                "name": "Favorites",
+                "sort": 0,
+                "collapseSeries": True,
+                "books": book_paths,
+            }
+        ],
+    }
+    (crosspoint_dir / "collections.json").write_text(json.dumps(doc))
+
+
+def prepare_fs(temp_root: Path, book: Path, shelf: bool) -> str:
+    fs_root = temp_root / "fs_"
+    books_dir = fs_root / "books"
     books_dir.mkdir(parents=True, exist_ok=True)
 
-    target = books_dir / book.name
-    shutil.copy2(book, target)
-    return f"/books/{book.name}"
+    shutil.copy2(book, books_dir / book.name)
+    opened = f"/books/{book.name}"
+    if shelf:
+        cover_paths = build_cover_fixtures(books_dir)
+        # Lead the shelf with real-cover fixtures, then the opened reader book
+        # (a title-fallback card) so the grid shows both kinds of cell.
+        write_collections(fs_root / ".crosspoint", [*cover_paths, opened])
+    return opened
 
 
 def run_smoke(args: argparse.Namespace) -> int:
+    pio_env = DEVICE_ENVS[args.device]
+    program = program_path(pio_env)
+
     book = Path(args.book).resolve()
     if not book.exists():
         print(f"Smoke test book not found: {book}", file=sys.stderr)
         return 2
 
     if args.build:
-        build_simulator()
+        build_simulator(pio_env)
 
-    if not PROGRAM.exists():
-        print(f"Simulator binary not found: {PROGRAM}", file=sys.stderr)
-        print("Run: pio run -e simulator", file=sys.stderr)
+    if not program.exists():
+        print(f"Simulator binary not found: {program}", file=sys.stderr)
+        print(f"Run: pio run -e {pio_env}", file=sys.stderr)
         return 2
 
     with tempfile.TemporaryDirectory(prefix="crossink-sim-smoke-") as temp_dir_name:
         temp_root = Path(temp_dir_name)
-        simulator_book_path = prepare_fs(temp_root, book)
+        simulator_book_path = prepare_fs(temp_root, book, args.shelf)
 
         env = os.environ.copy()
         env["CROSSINK_SIMULATOR_SMOKE_TEST"] = "1"
@@ -81,9 +197,13 @@ def run_smoke(args: argparse.Namespace) -> int:
         if args.headless:
             env.setdefault("SDL_VIDEODRIVER", "dummy")
 
-        print(f"Running simulator smoke test with isolated fs_: {temp_root / 'fs_'}", flush=True)
+        print(
+            f"Running simulator smoke test ({args.device}/{pio_env}) "
+            f"with isolated fs_: {temp_root / 'fs_'}",
+            flush=True,
+        )
         proc = subprocess.run(
-            [str(PROGRAM)],
+            [str(program)],
             cwd=temp_root,
             env=env,
             text=True,
@@ -112,6 +232,8 @@ def run_smoke(args: argparse.Namespace) -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=sorted(DEVICE_ENVS), default="x4", help="Panel to simulate: x4 (800x480) or x3 (792x528)")
+    parser.add_argument("--shelf", action="store_true", help="Seed a Favorites collection of cover-bearing fixtures to exercise the multi-cover shelf grid")
     parser.add_argument("--book", default=str(DEFAULT_BOOK), help="EPUB fixture to copy into the isolated simulator fs_")
     parser.add_argument("--timeout", type=int, default=45, help="Seconds before the simulator run is treated as hung")
     parser.add_argument("--page-turns", type=int, default=2, help="Number of EPUB page-forward taps to run")

--- a/src/LibraryIndex.cpp
+++ b/src/LibraryIndex.cpp
@@ -312,14 +312,14 @@ bool LibraryIndex::saveToFile() const {
   // build a JsonDocument + serialized String copy of the whole index in RAM
   // (the OOM-on-save that boot-looped large libraries).
   file.print(LIBRARY_INDEX_HEADER);
-  file.print('\n');
+  file.print("\n");
   char numbuf[24];
   for (const auto& e : entries) {
     snprintf(numbuf, sizeof(numbuf), "%llu", static_cast<unsigned long long>(e.firstSeenMillis));
     file.print(numbuf);
-    file.print('\t');
+    file.print("\t");
     file.print(e.path.c_str());
-    file.print('\n');
+    file.print("\n");
   }
   file.close();
   return true;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -830,7 +830,12 @@ void SleepActivity::composePngOverReaderPage(const std::string& pngPath) const {
 
   if (overlayPageBufferTrusted) {
     renderer.restoreBwBuffer();
-  } else if (!path.empty()) {
+  } else if (canSnapshotOverlayBackground && !path.empty()) {
+    // Only use a reader page as the background when we actually slept from a
+    // book. Sleeping from elsewhere (e.g. the home carousel) must NOT pull the
+    // last-opened book's page in as a backdrop — that surfaces a stale cover
+    // that reads as a "zoomed-in home screen". In that case fall through to a
+    // clean white background below.
     backgroundWasRebuilt = renderSavedReaderPage();
     if (!backgroundWasRebuilt) {
       if (overlayPageBufferStored) {
@@ -842,6 +847,7 @@ void SleepActivity::composePngOverReaderPage(const std::string& pngPath) const {
       }
     }
   } else {
+    // Not sleeping from a book: blank background behind the (transparent) PNG.
     renderer.clearScreen();
   }
 
@@ -922,7 +928,11 @@ void SleepActivity::renderOverlaySleepScreen() const {
   // popup was drawn. Otherwise, rebuild from the saved position.
   if (overlayPageBufferTrusted) {
     renderer.restoreBwBuffer();
-  } else if (!path.empty()) {
+  } else if (canSnapshotOverlayBackground && !path.empty()) {
+    // Only rebuild the reader page as the overlay background when we slept from
+    // a book. From the home carousel (or anywhere else) the last-opened book's
+    // page must not be pulled in — it reads as a "zoomed-in home screen". Fall
+    // through to a clean white background below instead.
     backgroundWasRebuilt = renderSavedReaderPage();
 
     if (!backgroundWasRebuilt) {
@@ -935,6 +945,7 @@ void SleepActivity::renderOverlaySleepScreen() const {
       }
     }
   } else {
+    // Not sleeping from a book: blank background behind the overlay image.
     renderer.clearScreen();
   }
 

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -162,6 +162,30 @@ bool hasThumbnailPlaceholder(const std::string& coverBmpPath) {
   return coverBmpPath.find("[WIDTH]") != std::string::npos || coverBmpPath.find("[HEIGHT]") != std::string::npos;
 }
 
+// A cover thumbnail counts as present only if it exists AND parses as a valid
+// BMP with non-zero dimensions — the exact test the Lyra Carousel renderer
+// applies before drawing it (LyraCarouselTheme::drawRecentBookCover). A file
+// that exists but won't parse (e.g. a truncated/corrupt thumb left by an older
+// build, or a partial write) is otherwise trusted by Storage.exists(), so
+// generation is skipped and the carousel falls back to the placeholder forever
+// — even though the same book's cover renders fine in every other theme, which
+// use different-dimension thumbs. Deleting the bad file here forces a one-shot
+// regeneration. Using the renderer's own criteria means we never reject a thumb
+// the renderer would have accepted (no needless regen churn).
+bool carouselThumbMissingOrInvalid(const std::string& thumbPath) {
+  if (thumbPath.empty()) return true;
+  FsFile file;
+  if (!Storage.openFileForRead("HOME", thumbPath, file)) return true;  // genuinely missing
+  Bitmap bitmap(file);
+  const bool valid = bitmap.parseHeaders() == BmpReaderError::Ok && bitmap.getWidth() > 0 && bitmap.getHeight() > 0;
+  file.close();
+  if (!valid) {
+    LOG_INF("HOME", "carousel: invalid cover thumb, deleting to regenerate: %s", thumbPath.c_str());
+    Storage.remove(thumbPath.c_str());
+  }
+  return !valid;
+}
+
 std::string getReusableCoverPath(const RecentBook& book) {
   if (FsHelpers::hasEpubExtension(book.path)) {
     return Epub(book.path, "/.crosspoint").getThumbBmpPath();
@@ -519,6 +543,19 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
   // re-snapshots. Without this, a freshly-opened book stays a placeholder.
   freeCoverBuffer();
 
+  // Also reclaim the carousel frame cache (~52 KB) before decoding covers.
+  // Cover generation needs a large contiguous block — a ~32 KB zip-inflate
+  // window plus the image decoder (PNG ~42 KB, JPEG ~17 KB). With the frame
+  // cache resident, the single largest cover (often a PNG) OOMs every pass and
+  // is stranded on a placeholder forever, while smaller covers succeed. The
+  // repeated failure popups also drop the Flow home fast-path cache, which
+  // makes navigation feel sluggish. The next render re-warms the frame from the
+  // freshly generated BMP thumbnails (cheap — no re-decode). Mirrors the
+  // free order used in onExit().
+  gCarouselCache.invalidate();
+  freeCarouselFrames();
+  carouselFramesReady = false;
+
   const bool isCarouselTheme =
       static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
   const bool isMinimal = isMinimalTheme();
@@ -542,8 +579,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                                                                   LyraCarouselTheme::kCenterThumbH);
         const std::string sidePath = UITheme::getCoverThumbPath(book.coverBmpPath, LyraCarouselTheme::kSideCoverW,
                                                                 LyraCarouselTheme::kSideCoverH);
-        const bool centerMissing = !Storage.exists(centerPath.c_str());
-        const bool sideMissing = !Storage.exists(sidePath.c_str());
+        // Validate (not just exists): a corrupt/truncated thumb must be treated
+        // as missing so it regenerates, else the carousel is stuck on a
+        // placeholder while other themes (different thumb sizes) show the cover.
+        const bool centerMissing = carouselThumbMissingOrInvalid(centerPath);
+        const bool sideMissing = carouselThumbMissingOrInvalid(sidePath);
 
         if (centerMissing || sideMissing) {
           if (FsHelpers::hasEpubExtension(book.path)) {
@@ -567,6 +607,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                                                      LyraCarouselTheme::kSideCoverH) &&
                         success;
             if (!success) {
+              // Log heap at the point of failure so a serial capture can tell
+              // OOM (low free/maxAlloc -> headroom problem) from a genuinely
+              // undecodable cover (ample heap -> format issue).
+              LOG_ERR("HOME", "carousel cover gen failed: %s (free=%u maxAlloc=%u)", book.path.c_str(),
+                      ESP.getFreeHeap(), ESP.getMaxAllocHeap());
               updateRecentBookCoverPath(book, "");
               book.coverBmpPath = "";
             } else {
@@ -639,6 +684,8 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               success = epub.generateThumbBmpNoIndex(0, coverHeight);
             }
             if (!success) {
+              LOG_ERR("HOME", "recent cover gen failed: %s (free=%u maxAlloc=%u)", book.path.c_str(),
+                      ESP.getFreeHeap(), ESP.getMaxAllocHeap());
               updateRecentBookCoverPath(book, "");
               book.coverBmpPath = "";
             } else {
@@ -1511,6 +1558,19 @@ void HomeActivity::showShelfHeaderActionMenu() {
 void HomeActivity::onEnter() {
   Activity::onEnter();
 
+  // ActivityManager::loop() releases the render lock *before* calling onEnter
+  // (so each activity decides whether it needs it). HomeActivity::onEnter
+  // rebuilds recentBooks and — on the Lyra Carousel theme — pre-renders
+  // carousel frames, which writes the framebuffer, mutates the shared global
+  // gCarouselCache, and runs the JPEG cover decoder. The render task touches
+  // all of that under the lock, so without holding it here a concurrently
+  // notified render() races us. That race corrupted the heap and tripped
+  // `xTaskPriorityDisinherit` (mutex released by a non-owner) during carousel
+  // cover decode. Hold the lock across the whole setup to serialize with
+  // render(). Safe from deadlock: onEnter is always called with the lock
+  // released, and nothing below re-takes it or blocks on the render task.
+  RenderLock lock;
+
   hasOpdsServers = OPDS_STORE.hasServers();
   const bool isCarouselTheme =
       static_cast<CrossPointSettings::UI_THEME>(SETTINGS.uiTheme) == CrossPointSettings::UI_THEME::LYRA_CAROUSEL;
@@ -1831,6 +1891,13 @@ bool HomeActivity::buildCarouselCacheFile(const std::string& cacheKey, uint64_t 
     if (!progressFrameBuffer) {
       LOG_ERR("HOME", "carousel: failed to allocate progress overlay buffer");
       showProgressPopup = false;
+      // Heap is too tight for the animated progress bar (it needs a full-frame
+      // backup to repaint between frames). Still show a static "Loading…" so
+      // the warmup doesn't look like a hang. The build below renders frames to
+      // SD without calling displayBuffer(), so this popup stays on the panel
+      // until warmup finishes and the next render paints the carousel.
+      GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
+      renderer.displayBuffer();
     } else {
       popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
       GUI.fillPopupProgress(renderer, popupRect, 0);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1223,6 +1223,7 @@ void EpubReaderActivity::executeReaderQuickAction(CrossPointSettings::LONG_PRESS
                                // (user had no bonded remote), do it now via the same mechanism the
                                // reader menu's BLUETOOTH action uses — exit-on-success so the user
                                // lands back in the book after pairing.
+#ifndef SIMULATOR
                                if (menu && menu->requestBluetoothFlow) {
                                  startActivityForResult(
                                      std::make_unique<BluetoothSettingsActivity>(
@@ -1231,6 +1232,7 @@ void EpubReaderActivity::executeReaderQuickAction(CrossPointSettings::LONG_PRESS
                                      [this](const ActivityResult&) { requestUpdate(); });
                                  return;
                                }
+#endif  // SIMULATOR: BLE pairing UI needs NimBLE; no-op in the native simulator.
                                // No explicit requestUpdate() — ActivityManager's Pop path will
                                // automatically requestUpdateAndWait(), and adding our own here
                                // would cause the reader page to render twice (the dark→light

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -176,6 +176,7 @@ void EpubReaderMenuActivity::loop() {
     }
 
     if (selectedAction == MenuAction::BLUETOOTH) {
+#ifndef SIMULATOR
       // exitOnSuccessfulConnect=true: when the user pairs a new remote or
       // reconnects to a bonded one from inside the book, BluetoothSettings
       // sets MenuResult.autoExitParent=true and pops itself. We then also
@@ -197,6 +198,7 @@ void EpubReaderMenuActivity::loop() {
             }
             requestUpdate();
           });
+#endif  // SIMULATOR: BLE pairing UI needs NimBLE; no-op in the native simulator.
       return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,6 +610,7 @@ void putTiltSensorToSleepForDeepSleep() {
 // ~500ms to register a press; any tap shorter than that would be invisible. The deep-sleep
 // wake itself already proved the button went LOW, so we only need to determine "still held?"
 // vs "already released?" right now.
+#ifndef SIMULATOR
 bool detectScreensaverCycleTap() {
   const unsigned long start = millis();
   while (digitalRead(InputManager::POWER_BUTTON_PIN) == LOW && (millis() - start) < SCREENSAVER_TAP_MAX_MS) {
@@ -670,6 +671,16 @@ bool consumeCompletedSleepEntryTap() {
   sleepEntryTapPending = false;
   return true;
 }
+#else
+// Simulator: no power-button GPIO or ISRs — cycle-screensaver is on-device
+// only. No-op stubs so callers compile (SETTINGS.cycleScreensaverOnTap stays
+// off in the sim, so these are never actually reached).
+bool detectScreensaverCycleTap() { return false; }
+bool pollForCycleTapDuringSleepEntry() { return false; }
+void armSleepEntryTapIsr() {}
+void disarmSleepEntryTapIsr() {}
+bool consumeCompletedSleepEntryTap() { return false; }
+#endif
 
 constexpr char SLEEP_FRAME_FILE[] = "/.crosspoint/sleep_frame.bin";
 
@@ -952,6 +963,7 @@ void setup() {
   UITheme::getInstance().reload();
   ButtonNavigator::setMappedInputManager(mappedInputManager);
 
+#ifndef SIMULATOR
   {
     auto& btMgr = BluetoothHIDManager::getInstance();
     btMgr.setButtonInjector(
@@ -960,6 +972,7 @@ void setup() {
     btMgr.setReaderContextCallback([]() { return gBluetoothReaderContext; });
     btMgr.setBondedDevice(SETTINGS.bleBondedDeviceAddr, SETTINGS.bleBondedDeviceName);
   }
+#endif  // SIMULATOR: BLE injection uses ESP32 GPIO virtual buttons; no-op in sim.
 
   const auto wakeupReason = gpio.getWakeupReason();
   LOG_INF("BOOT", "Wake route: %s", wakeupRouteName(wakeupReason));

--- a/src/simulator/SimulatorSmokeTest.cpp
+++ b/src/simulator/SimulatorSmokeTest.cpp
@@ -2,10 +2,12 @@
 
 #include "SimulatorSmokeTest.h"
 
+#include <HalDisplay.h>
 #include <HalStorage.h>
 #include <Logging.h>
 
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <memory>
@@ -35,6 +37,7 @@ enum class SmokeStep : uint8_t {
   Sleep,
   Reader,
   ReaderInput,
+  HomePopulated,
   Done,
 };
 
@@ -106,11 +109,68 @@ class SimulatorSmokeTest {
     std::_Exit(2);
   }
 
+  // Dump the current (BW) framebuffer to a 24-bit BMP when CROSSINK_SIMULATOR_DUMP_DIR
+  // is set. Panel-native orientation (e.g. 792x528 on X3); rotate to portrait
+  // for viewing. Used to eyeball theme layout on different panels (X3 vs X4)
+  // without hardware.
+  static void dumpFramebufferBmp(const char* name) {
+    const char* dir = std::getenv("CROSSINK_SIMULATOR_DUMP_DIR");
+    if (dir == nullptr || dir[0] == '\0') return;
+    const uint8_t* fb = renderer.getFrameBuffer();
+    if (fb == nullptr) return;
+    const int W = HalDisplay::DISPLAY_WIDTH;
+    const int H = HalDisplay::DISPLAY_HEIGHT;
+    const int widthBytes = (W + 7) / 8;
+    const int rowSize = ((W * 3 + 3) / 4) * 4;
+    const uint32_t dataSize = static_cast<uint32_t>(rowSize) * static_cast<uint32_t>(H);
+    char path[512];
+    std::snprintf(path, sizeof(path), "%s/%s.bmp", dir, name);
+    FILE* f = std::fopen(path, "wb");
+    if (f == nullptr) return;
+    auto w16 = [&](uint16_t v) { std::fputc(v & 0xFF, f); std::fputc((v >> 8) & 0xFF, f); };
+    auto w32 = [&](uint32_t v) {
+      std::fputc(v & 0xFF, f);
+      std::fputc((v >> 8) & 0xFF, f);
+      std::fputc((v >> 16) & 0xFF, f);
+      std::fputc((v >> 24) & 0xFF, f);
+    };
+    std::fputc('B', f);
+    std::fputc('M', f);
+    w32(54 + dataSize);
+    w32(0);
+    w32(54);
+    w32(40);
+    w32(static_cast<uint32_t>(W));
+    w32(static_cast<uint32_t>(-H));  // negative height = top-down rows
+    w16(1);
+    w16(24);
+    w32(0);
+    w32(dataSize);
+    w32(2835);
+    w32(2835);
+    w32(0);
+    w32(0);
+    std::vector<uint8_t> row(static_cast<size_t>(rowSize), 0);
+    for (int y = 0; y < H; ++y) {
+      for (int x = 0; x < W; ++x) {
+        const uint8_t byte = fb[y * widthBytes + (x >> 3)];
+        const uint8_t v = ((byte >> (7 - (x & 7))) & 1) ? 0xFF : 0x00;  // bit set = white
+        row[static_cast<size_t>(x) * 3 + 0] = v;
+        row[static_cast<size_t>(x) * 3 + 1] = v;
+        row[static_cast<size_t>(x) * 3 + 2] = v;
+      }
+      std::fwrite(row.data(), 1, static_cast<size_t>(rowSize), f);
+    }
+    std::fclose(f);
+    LOG_INF("SMOKE", "Dumped framebuffer: %s (%dx%d panel-native)", path, W, H);
+  }
+
   static void renderCurrentStep(const char* name) {
     LOG_INF("SMOKE", "Rendering %s", name);
     if (activityManager.requestUpdateAndWait() != RequestUpdateResult::Rendered) {
       fail("Render was rejected for %s", name);
     }
+    dumpFramebufferBmp(name);
   }
 
   void queueStep(const char* name, SmokeStep nextStep, int framesToSettle = 3) {
@@ -200,6 +260,13 @@ class SimulatorSmokeTest {
         runReaderInputScript();
         break;
 
+      case SmokeStep::HomePopulated:
+        // Return Home after the reader has opened a book so the Flow carousel
+        // and shelf render with an actual cover (densest layout to eyeball on X3).
+        activityManager.goHome();
+        queueStep("Home Populated", SmokeStep::Done, 6);
+        break;
+
       case SmokeStep::Done:
         LOG_INF("SMOKE", "Simulator smoke test passed");
         std::_Exit(0);
@@ -257,7 +324,7 @@ class SimulatorSmokeTest {
 
   void runReaderInputScript() {
     if (scriptIndex >= inputScript.size()) {
-      step = SmokeStep::Done;
+      step = SmokeStep::HomePopulated;
       return;
     }
 

--- a/src/simulator/sim_stubs/BluetoothHIDManager.h
+++ b/src/simulator/sim_stubs/BluetoothHIDManager.h
@@ -1,0 +1,76 @@
+#pragma once
+// Simulator-only no-op stub for the NimBLE-based BluetoothHIDManager.
+//
+// The real implementation (lib/hal/BluetoothHIDManager.{h,cpp}) depends on
+// NimBLE/ESP32 and is unavailable in the native simulator build (the sim
+// lib_ignores `hal`). This stub lets CrumBLE compile + run in the simulator,
+// where Bluetooth is simply a no-op (you can't pair a real remote to the host).
+// It is only on the include path for env:simulator (-Isrc/simulator/sim_stubs);
+// on-device builds use the real lib/hal header.
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+struct BluetoothDevice {
+  std::string address;
+  std::string name;
+  int rssi = 0;
+  bool isHID = false;
+};
+
+class BluetoothHIDManager {
+ public:
+  static BluetoothHIDManager& getInstance() {
+    static BluetoothHIDManager instance;
+    return instance;
+  }
+
+  // Lifecycle
+  bool enable() { return false; }
+  bool disable() { return true; }
+  bool isEnabled() const { return false; }
+
+  // Deferred enable/disable
+  void requestDisableLater() {}
+  bool tryDisableIfRequested() { return false; }
+  void requestEnableLater() {}
+  bool tryEnableIfRequested() { return false; }
+
+  // Scanning
+  void startScan(uint32_t /*durationMs*/ = 10000) {}
+  void stopScan() {}
+  bool isScanning() const { return false; }
+  const std::vector<BluetoothDevice>& getDiscoveredDevices() const { return _discoveredDevices; }
+
+  // Connection
+  bool connectToDevice(const std::string& /*address*/) { return false; }
+  bool disconnectFromDevice(const std::string& /*address*/) { return false; }
+  bool isConnected(const std::string& /*address*/) const { return false; }
+  std::vector<std::string> getConnectedDevices() const { return {}; }
+
+  // Input handling
+  void processInputEvents() {}
+  void setInputCallback(std::function<void(uint16_t)> /*cb*/) {}
+  void setLearnInputCallback(std::function<void(uint8_t, uint8_t)> /*cb*/) {}
+  void setButtonInjector(std::function<void(uint8_t, bool)> /*injector*/) {}
+  void setReaderContextCallback(std::function<bool()> /*cb*/) {}
+  void setButtonActivityNotifier(std::function<void(uint8_t)> /*notifier*/) {}
+  void setDebugCaptureEnabled(bool /*enabled*/) {}
+  bool isDebugCaptureEnabled() const { return false; }
+  void setBondedDevice(const std::string& /*address*/, const std::string& /*name*/ = "") {}
+  void updateActivity() {}
+  void checkAutoReconnect(bool /*userInputDetected*/ = false) {}
+  bool hasRecentActivity() const { return false; }
+  bool hadRecentFree2Input(unsigned long /*windowMs*/ = 1500) const { return false; }
+
+  // State persistence
+  void saveState() {}
+  void loadState() {}
+
+  std::string lastError;
+
+ private:
+  BluetoothHIDManager() = default;
+  std::vector<BluetoothDevice> _discoveredDevices;
+};


### PR DESCRIPTION
## Summary
Patch release on top of v3.0.0. Device stability/UX fixes (all verified on hardware) plus dev-only X4/X3 simulator tooling.

### Device fixes (apply to both X4 and X3 — single firmware, runtime-detected)
- **fix(home): Lyra Carousel crash** — `HomeActivity::onEnter` rebuilt `recentBooks` and pre-rendered carousel frames *without* the render lock (ActivityManager releases it before `onEnter`), racing the render task over the framebuffer / shared `gCarouselCache` / image decoders. The race corrupted the heap and tripped `assert xTaskPriorityDisinherit` (a mutex freed by a non-owner) during cover decode. `onEnter` now holds the `RenderLock`.
- **fix(home): carousel-only stuck placeholder cover** — a thumb that exists but won't parse (truncated/corrupt) was trusted by `Storage.exists()`, so generation was skipped and the renderer silently fell back to a placeholder (only on Lyra Carousel, which uses its own fixed thumb sizes). The loader now validates thumbs with the renderer's own `parseHeaders` criteria and deletes an invalid one so it regenerates. Also frees the carousel frame cache (~52 KB) before decode for more headroom, and logs heap on failure.
- **fix(home): warmup UX** — when the progress-overlay backup buffer can't allocate, draw a static "Loading…" instead of a frozen-looking screen.
- **fix(sleep): transparent-PNG background** — Custom/Overlay sleep modes no longer re-render the last-opened book's page as the background unless you actually slept from a book (was surfacing a stale cover that looked like a zoomed-in home screen). Falls back to white otherwise.

### Dev tooling
- **test(sim): X4/X3 simulator envs** — split into shared `[simulator_base]` + `[env:simulator]` (X4) + `[env:simulator_x3]`; runner gains `--device x4|x3` and a `--shelf` cover-fixture mode. Flow layout verified at 792×528. (No device-code changes; X3 runtime support already shipped in 3.0.0.)

Version bumped to **3.0.1** in `platformio.ini`.

## Test plan
- [x] Lyra Carousel: no crash on entry/navigation with a populated library
- [x] Stuck cover regenerates and displays on Lyra Carousel
- [x] Flow home navigation feels fast again
- [x] Static "Loading…" shows during first carousel warmup
- [x] Transparent-PNG sleep from home → white background (not a stale cover)
- [x] `tiny` builds + flashes; X4 + X3 simulator builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)