### PR TITLE
feat(cmb): CrumBLE Book sidecar -- fast cold open + heap-light section build

### DIFF
--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "CmbWriter.h"
+#include "FsHelpers/FsHelpers.h"
 
 namespace cmb {
 
@@ -31,18 +32,30 @@ namespace {
 // attribute encountered within a paragraph (paragraph-boundary tag
 // OR a wrapping `<span>` / `<a>`).
 //
-// `<img>` and other media tags are deliberately ignored in this
-// commit -- they need an image ref resolver pass (to look up the
-// EPUB ZIP entry, get the local-file-header offset, register in the
-// .cmb image table) that arrives in the next checkpoint.
+// `<img>` records: the walker resolves the `src` attribute against
+// the chapter file's location, looks up the resulting path's
+// local-file-header offset in the EPUB ZIP (via
+// `Epub::getZipLocalHeaderOffset`), adds an entry to the .cmb image
+// table (`CmbWriter::add_image_ref`, dedup on offset+w+h), and emits
+// a `kCmbBlockImage` paragraph carrying the resulting image key.
+// `<hr>` emits a `kCmbBlockHr` record. Resolution failures (image
+// not in the EPUB ZIP, malformed src, etc.) skip the image silently;
+// the reader treats missing keys as placeholders.
 //
-// The output sink is a std::function<bool(const CmbParagraph&)> that
-// returns false to stop the parse (e.g. on writer I/O failure).
+// The walker holds raw pointers to its writer + Epub for the
+// duration of one feed/flush; lifetime is the caller's
+// responsibility (which is the convert_epub_to_cmb function below,
+// where both objects live on the stack).
 class XhtmlParagraphWalker {
  public:
   using Sink = bool (*)(void* ctx, const CmbParagraph&);
 
-  XhtmlParagraphWalker(Sink sink, void* ctx) : sink_(sink), ctx_(ctx) {}
+  XhtmlParagraphWalker(Sink sink, void* ctx, CmbWriter* writer, Epub* epub, std::string chapter_path)
+      : sink_(sink),
+        ctx_(ctx),
+        writer_(writer),
+        epub_(epub),
+        chapter_path_(std::move(chapter_path)) {}
 
   // Feed a chunk of XHTML bytes through expat. Returns false on
   // expat parse error or sink-rejection; partial state from previous
@@ -104,6 +117,44 @@ class XhtmlParagraphWalker {
   static bool is_underline_tag(const char* name) { return tag_eq(name, "u") || tag_eq(name, "ins"); }
   static bool is_strike_tag(const char* name) { return tag_eq(name, "s") || tag_eq(name, "strike") || tag_eq(name, "del"); }
   static bool is_hard_break_tag(const char* name) { return tag_eq(name, "br"); }
+  static bool is_image_tag(const char* name) { return tag_eq(name, "img") || tag_eq(name, "image"); }
+  static bool is_hr_tag(const char* name) { return tag_eq(name, "hr"); }
+
+  // Resolve a relative URL like "../images/cover.jpg" against the
+  // chapter file's full ZIP path (e.g. "OEBPS/Text/c1.xhtml"). Strips
+  // a leading "/" (treated as ZIP-root-absolute), joins the chapter's
+  // directory prefix onto the relative path, then runs through
+  // FsHelpers::normalisePath to collapse "./" and "../" components.
+  static std::string resolve_against_chapter(const std::string& chapter_path, std::string_view rel) {
+    if (rel.empty()) return {};
+    if (rel.front() == '/') {
+      return std::string(rel.substr(1));
+    }
+    const size_t slash = chapter_path.rfind('/');
+    std::string joined;
+    if (slash != std::string::npos) {
+      joined.assign(chapter_path, 0, slash + 1);
+    }
+    joined.append(rel);
+    return FsHelpers::normalisePath(joined);
+  }
+
+  // Parse a non-negative integer attribute (e.g. width="100"). Strips
+  // a trailing "px" suffix that EPUBs sometimes carry. Returns 0 on
+  // any parse failure -- the .cmb image-ref table interprets 0 as
+  // "resolve at display time" so we can't accidentally store a bad
+  // dimension.
+  static uint16_t parse_dimension_attr(const char* value) {
+    if (value == nullptr) return 0;
+    uint32_t n = 0;
+    const char* p = value;
+    while (*p >= '0' && *p <= '9') {
+      n = n * 10 + static_cast<uint32_t>(*p - '0');
+      if (n > 0xFFFF) return 0;
+      ++p;
+    }
+    return static_cast<uint16_t>(n);
+  }
 
   // ---- event handlers ----
 
@@ -147,9 +198,67 @@ class XhtmlParagraphWalker {
       ++strike_depth_;
       return;
     }
-    // <img>, <hr>, etc. are intentionally not handled here -- left for
-    // a follow-up image-ref + block emitter that needs more EPUB
-    // context than the walker has.
+    if (is_image_tag(name)) {
+      // Emit any text paragraph in progress so the image sits as its
+      // own block. Then resolve the src + width/height attrs and
+      // record an image-ref entry; the writer dedups on (offset, w, h).
+      std::string src;
+      uint16_t attr_w = 0;
+      uint16_t attr_h = 0;
+      std::string anchor_id;
+      for (int i = 0; atts && atts[i]; i += 2) {
+        if (tag_eq(atts[i], "src")) {
+          src = atts[i + 1];
+        } else if (tag_eq(atts[i], "width")) {
+          attr_w = parse_dimension_attr(atts[i + 1]);
+        } else if (tag_eq(atts[i], "height")) {
+          attr_h = parse_dimension_attr(atts[i + 1]);
+        } else if (tag_eq(atts[i], "id")) {
+          anchor_id = atts[i + 1];
+        } else if (tag_eq(atts[i], "xlink:href")) {
+          // SVG <image> uses xlink:href instead of src.
+          if (src.empty()) src = atts[i + 1];
+        }
+      }
+
+      // Flush any pending text paragraph. If src resolution fails,
+      // we still keep the flush -- the image markup is consumed
+      // either way (no point keeping it accumulating in text).
+      emit_pending();
+
+      if (src.empty() || writer_ == nullptr || epub_ == nullptr) {
+        return;
+      }
+      const std::string resolved = resolve_against_chapter(chapter_path_, src);
+      if (resolved.empty()) return;
+
+      uint32_t local_header_offset = 0;
+      if (!epub_->getZipLocalHeaderOffset(resolved, &local_header_offset)) {
+        // Image referenced by the XHTML but not present in the ZIP
+        // (broken EPUB) -- skip silently; reader handles missing key
+        // by showing a placeholder.
+        return;
+      }
+      const uint16_t image_key = writer_->add_image_ref(local_header_offset, attr_w, attr_h);
+
+      CmbParagraph p;
+      p.type = kCmbBlockImage;
+      p.image_key = image_key;
+      p.anchor_id = std::move(anchor_id);
+      if (sink_ != nullptr && !sink_(ctx_, p)) {
+        sink_failed_ = true;
+      }
+      return;
+    }
+    if (is_hr_tag(name)) {
+      emit_pending();
+      CmbParagraph p;
+      p.type = kCmbBlockHr;
+      if (sink_ != nullptr && !sink_(ctx_, p)) {
+        sink_failed_ = true;
+      }
+      return;
+    }
   }
 
   void on_end(const char* name) {
@@ -288,6 +397,13 @@ class XhtmlParagraphWalker {
   void* ctx_ = nullptr;
   bool sink_failed_ = false;
 
+  // For <img> resolution: chapter file's path inside the EPUB ZIP
+  // (full path; relative srcs are resolved against this), plus the
+  // Epub + CmbWriter used to look up + register image refs.
+  CmbWriter* writer_ = nullptr;
+  Epub* epub_ = nullptr;
+  std::string chapter_path_;
+
   // Per-paragraph accumulator.
   std::string current_text_;
   std::vector<CmbStyleRun> current_runs_;
@@ -337,8 +453,11 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
     if (raw != nullptr && raw_size > 0) {
       // Fresh walker per chapter -- expat carries some per-document
       // state (DTD declarations, namespace tables) we don't want to
-      // bleed across spine items.
-      XhtmlParagraphWalker walker(writer_sink, &ctx);
+      // bleed across spine items. The chapter's normalised full path
+      // is what <img src> resolution joins against.
+      const std::string chapter_full_path =
+          FsHelpers::normalisePath(book.getBasePath() + entry.href);
+      XhtmlParagraphWalker walker(writer_sink, &ctx, &w, &book, chapter_full_path);
       const bool parsed_ok = walker.feed(reinterpret_cast<const char*>(raw), raw_size, /*is_final=*/true);
       // Flush whatever the walker buffered past its last paragraph
       // close (handles XHTML that ends without a closing </p>).

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -10,6 +10,7 @@
 
 #include <FsHelpers.h>
 #include <HalStorage.h>  // pulled transitively by Epub.h; declared explicitly so PIO chain LDF tracks the dep
+#include <Logging.h>
 
 #include "CmbWriter.h"
 
@@ -440,7 +441,10 @@ bool writer_sink(void* ctx_v, const CmbParagraph& p) {
 
 bool convert_epub_to_cmb(Epub& book, const char* output_path) {
   CmbWriter w;
-  if (!w.open(output_path)) return false;
+  if (!w.open(output_path)) {
+    LOG_ERR("CMB", "convert: writer.open(%s) failed", output_path);
+    return false;
+  }
 
   WriterSinkCtx ctx{&w, false};
 
@@ -496,6 +500,10 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
       if (!parsed_ok || !flushed_ok || ctx.any_failure) {
         // Parse error / writer error -- finalize the chapter so the
         // descriptor table is consistent, then bail.
+        LOG_ERR("CMB",
+                "convert: chapter %d failed (href=%s rawSize=%u parsed=%u flushed=%u sink_failure=%u)", ci,
+                entry.href.c_str(), static_cast<unsigned>(raw_size), parsed_ok ? 1u : 0u, flushed_ok ? 1u : 0u,
+                ctx.any_failure ? 1u : 0u);
         std::free(raw);
         w.end_chapter();
         w.close();
@@ -523,6 +531,7 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
   }
 
   if (!w.finish(metadata)) {
+    LOG_ERR("CMB", "convert: writer.finish failed (chapters=%d toc=%d)", chapter_count, toc_count);
     w.close();
     return false;
   }

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -8,8 +8,10 @@
 #include <string_view>
 #include <vector>
 
+#include <FsHelpers.h>
+#include <HalStorage.h>  // pulled transitively by Epub.h; declared explicitly so PIO chain LDF tracks the dep
+
 #include "CmbWriter.h"
-#include "FsHelpers/FsHelpers.h"
 
 namespace cmb {
 

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -442,12 +442,22 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
 
   WriterSinkCtx ctx{&w, false};
 
-  // Collect spine hrefs as we walk so the writer can serialise them
-  // into the .cmb v2 metadata blob. Indexed by spine order (= the
-  // chapter index in .cmb), matching what BookMetadataCache expects.
+  // Collect the full BookMetadataCache-equivalent set as we walk so
+  // the writer can serialise it into the .cmb v3 metadata blob.
+  // spine[i].href + spine[i].cumulative_size match what
+  // BookMetadataCache::SpineEntry holds; cumulative_size is summed
+  // across spine entries via Epub::getItemSize, mirroring what
+  // BookMetadataCache::buildBookBin computes from the EPUB ZIP.
   const int chapter_count = book.getSpineItemsCount();
-  std::vector<std::string> spine_hrefs;
-  spine_hrefs.reserve(chapter_count);
+  CmbBookMetadata metadata;
+  metadata.title = book.getTitle();
+  metadata.author = book.getAuthor();
+  metadata.language = book.getLanguage();
+  metadata.cover_href = book.getCoverItemHref();
+  metadata.text_reference_href = book.getTextReferenceHref();
+  metadata.css_files = book.getCssFiles();
+  metadata.spine.reserve(chapter_count);
+  uint32_t cumulative = 0;
   for (int ci = 0; ci < chapter_count; ++ci) {
     const auto entry = book.getSpineItem(ci);
 
@@ -478,10 +488,25 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
     }
     std::free(raw);
     w.end_chapter();
-    spine_hrefs.push_back(entry.href);
+
+    // cumulative_size matches BookMetadataCache::SpineEntry semantics:
+    // running sum of inflated ZIP-entry sizes through and INCLUDING
+    // this spine item. The reader uses it for reading-progress math.
+    // getItemSize() failures (entry missing from ZIP -- unusual,
+    // implies a malformed EPUB) leave cumulative unchanged, which is
+    // a graceful degradation: the entry records the prior cumulative,
+    // which is wrong but not crash-y.
+    size_t inflated = 0;
+    if (book.getItemSize(entry.href, &inflated)) {
+      cumulative += static_cast<uint32_t>(inflated);
+    }
+    CmbSpineEntry cmb_entry;
+    cmb_entry.href = entry.href;
+    cmb_entry.cumulative_size = cumulative;
+    metadata.spine.push_back(std::move(cmb_entry));
   }
 
-  if (!w.finish(book.getTitle(), book.getAuthor(), spine_hrefs)) {
+  if (!w.finish(metadata)) {
     w.close();
     return false;
   }

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -1,0 +1,229 @@
+#include "CmbConverter.h"
+
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+#include "CmbWriter.h"
+
+namespace cmb {
+
+namespace {
+
+// Strip XHTML/HTML tags from a UTF-8 byte buffer and return the
+// resulting plain-text content. Single-pass, no regex, no expat
+// dependency. Handles:
+//   - Tags <foo> and </foo> -- skipped entirely (including attributes
+//     and self-closing forms like <br/>). Doesn't parse the tag name;
+//     just consumes characters until the matching '>'.
+//   - Comments <!-- ... --> -- skipped.
+//   - The common named entities (&amp;, &lt;, &gt;, &quot;, &apos;,
+//     &nbsp;) and numeric refs &#N; / &#xH;.
+//   - Whitespace collapse: any run of ASCII whitespace (space, tab,
+//     newline, CR, FF) becomes a single space. Leading + trailing
+//     whitespace is trimmed.
+//
+// Phase A.C v0 limitation: paragraph boundaries (<p>, <div>, <h1..6>,
+// <br/>) are NOT preserved -- the whole chapter collapses into one
+// run of words separated by spaces. Acceptable for round-trip testing
+// the writer/reader; v1 of the converter splits on these boundaries.
+std::string strip_html_to_plain_text(std::string_view src) {
+  std::string out;
+  // Reserve a guess: stripped text is usually 60-80% of source size.
+  out.reserve(src.size() * 3 / 4);
+
+  const size_t n = src.size();
+  size_t i = 0;
+  bool last_was_space = true;  // emits no leading whitespace
+
+  auto emit_char = [&](char c) {
+    if (c == '\0') return;
+    if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f') {
+      if (!last_was_space) {
+        out.push_back(' ');
+        last_was_space = true;
+      }
+      return;
+    }
+    out.push_back(c);
+    last_was_space = false;
+  };
+
+  auto emit_codepoint = [&](uint32_t cp) {
+    // Re-encode codepoint as UTF-8 bytes. Common case: ASCII falls
+    // through emit_char's whitespace handling cleanly.
+    if (cp < 0x80) {
+      emit_char(static_cast<char>(cp));
+    } else if (cp < 0x800) {
+      out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+      last_was_space = false;
+    } else if (cp < 0x10000) {
+      out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+      last_was_space = false;
+    } else if (cp < 0x110000) {
+      out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+      last_was_space = false;
+    }
+    // Codepoints >= 0x110000 are illegal -- silently drop.
+  };
+
+  while (i < n) {
+    const char c = src[i];
+    if (c == '<') {
+      // Comment? <!-- ... -->
+      if (i + 3 < n && src[i + 1] == '!' && src[i + 2] == '-' && src[i + 3] == '-') {
+        // Scan for "-->"
+        size_t j = i + 4;
+        while (j + 2 < n && !(src[j] == '-' && src[j + 1] == '-' && src[j + 2] == '>')) {
+          ++j;
+        }
+        i = (j + 2 < n) ? j + 3 : n;
+        // Treat comment as a separator (emit space so adjacent text
+        // doesn't run together when a comment splits it).
+        if (!last_was_space) {
+          out.push_back(' ');
+          last_was_space = true;
+        }
+        continue;
+      }
+      // Generic tag: skip to matching '>'. Doesn't try to parse the
+      // tag; intentionally permissive on malformed HTML.
+      while (i < n && src[i] != '>') ++i;
+      if (i < n) ++i;  // consume '>'
+      // Tags act as soft separators between text runs.
+      if (!last_was_space) {
+        out.push_back(' ');
+        last_was_space = true;
+      }
+      continue;
+    }
+    if (c == '&') {
+      // Entity. Common named refs + numeric refs.
+      // Scan for terminating ';' (cap at 8 chars to stay safe on
+      // malformed input).
+      size_t end = i + 1;
+      while (end < n && end < i + 10 && src[end] != ';' && src[end] != '<' && src[end] != '&') {
+        ++end;
+      }
+      if (end < n && src[end] == ';') {
+        const std::string_view entity = src.substr(i + 1, end - i - 1);
+        if (entity == "amp") {
+          emit_char('&');
+        } else if (entity == "lt") {
+          emit_char('<');
+        } else if (entity == "gt") {
+          emit_char('>');
+        } else if (entity == "quot") {
+          emit_char('"');
+        } else if (entity == "apos") {
+          emit_char('\'');
+        } else if (entity == "nbsp") {
+          emit_char(' ');
+        } else if (entity.size() >= 2 && entity[0] == '#') {
+          // Numeric ref: &#N; (decimal) or &#xH; / &#XH; (hex).
+          uint32_t cp = 0;
+          if (entity[1] == 'x' || entity[1] == 'X') {
+            for (size_t k = 2; k < entity.size(); ++k) {
+              const char d = entity[k];
+              if (d >= '0' && d <= '9') {
+                cp = cp * 16 + static_cast<uint32_t>(d - '0');
+              } else if (d >= 'a' && d <= 'f') {
+                cp = cp * 16 + static_cast<uint32_t>(d - 'a' + 10);
+              } else if (d >= 'A' && d <= 'F') {
+                cp = cp * 16 + static_cast<uint32_t>(d - 'A' + 10);
+              } else {
+                cp = 0;
+                break;
+              }
+            }
+          } else {
+            for (size_t k = 1; k < entity.size(); ++k) {
+              const char d = entity[k];
+              if (d < '0' || d > '9') {
+                cp = 0;
+                break;
+              }
+              cp = cp * 10 + static_cast<uint32_t>(d - '0');
+            }
+          }
+          if (cp != 0) emit_codepoint(cp);
+        }
+        // Unknown named entity -- drop silently. (Could fall back to
+        // emitting the raw '&...;' but that confuses downstream
+        // text-content callers more than dropping does.)
+        i = end + 1;
+        continue;
+      }
+      // No terminating ';' -- treat '&' as literal.
+      emit_char('&');
+      ++i;
+      continue;
+    }
+    emit_char(c);
+    ++i;
+  }
+
+  // Trim trailing whitespace (we always emit a single space for runs,
+  // so at most one trailing space to peel off).
+  if (!out.empty() && out.back() == ' ') {
+    out.pop_back();
+  }
+  return out;
+}
+
+}  // namespace
+
+bool convert_epub_to_cmb(Epub& book, const char* output_path) {
+  CmbWriter w;
+  if (!w.open(output_path)) return false;
+
+  const int chapter_count = book.getSpineItemsCount();
+  for (int ci = 0; ci < chapter_count; ++ci) {
+    const auto entry = book.getSpineItem(ci);
+
+    size_t raw_size = 0;
+    uint8_t* raw = book.readItemContentsToBytes(entry.href, &raw_size);
+
+    w.begin_chapter();
+    if (raw != nullptr && raw_size > 0) {
+      // Phase A.C v0: one paragraph per chapter containing all the
+      // stripped-of-tags text. Subsequent commits split on <p>/<div>/<h*>
+      // boundaries and capture inline styling.
+      std::string text = strip_html_to_plain_text(
+          std::string_view{reinterpret_cast<const char*>(raw), raw_size});
+      if (!text.empty()) {
+        CmbParagraph p;
+        p.type = kCmbBlockText;
+        p.text = std::move(text);
+        if (!w.write_paragraph(p)) {
+          // Write failure on this paragraph -- skip rest of chapter
+          // (end_chapter still writes the descriptor table for what
+          // we did emit) but treat the overall conversion as failed.
+          std::free(raw);
+          w.end_chapter();
+          w.close();
+          return false;
+        }
+      }
+    }
+    std::free(raw);
+    w.end_chapter();
+  }
+
+  if (!w.finish(book.getTitle(), book.getAuthor())) {
+    w.close();
+    return false;
+  }
+  w.close();
+  return true;
+}
+
+}  // namespace cmb

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -81,6 +81,10 @@ class XhtmlParagraphWalker {
       XML_SetDefaultHandlerExpand(parser_, &XhtmlParagraphWalker::default_thunk);
     }
     if (XML_Parse(parser_, data, static_cast<int>(size), is_final ? 1 : 0) == XML_STATUS_ERROR) {
+      const XML_Error code = XML_GetErrorCode(parser_);
+      LOG_ERR("CMB", "walker.feed: expat error %d (%s) at line %lu col %lu", static_cast<int>(code),
+              XML_ErrorString(code), static_cast<unsigned long>(XML_GetCurrentLineNumber(parser_)),
+              static_cast<unsigned long>(XML_GetCurrentColumnNumber(parser_)));
       return false;
     }
     return !sink_failed_;

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -13,6 +13,7 @@
 #include <Logging.h>
 
 #include "CmbWriter.h"
+#include "Epub/htmlEntities.h"
 
 namespace cmb {
 
@@ -70,6 +71,14 @@ class XhtmlParagraphWalker {
       XML_SetUserData(parser_, this);
       XML_SetElementHandler(parser_, &XhtmlParagraphWalker::start_thunk, &XhtmlParagraphWalker::end_thunk);
       XML_SetCharacterDataHandler(parser_, &XhtmlParagraphWalker::chars_thunk);
+      // EPUBs routinely use HTML entities (&nbsp; etc.) that expat
+      // doesn't know about. Without a default handler, the parser
+      // rejects them as undeclared entities -- which is why books
+      // like Light Bringer (which sprinkles &nbsp; throughout)
+      // failed to convert. Mirror ChapterHtmlSlimParser: pass any
+      // entity-shaped data through lookupHtmlEntity and re-emit
+      // the UTF-8 expansion as character data.
+      XML_SetDefaultHandlerExpand(parser_, &XhtmlParagraphWalker::default_thunk);
     }
     if (XML_Parse(parser_, data, static_cast<int>(size), is_final ? 1 : 0) == XML_STATUS_ERROR) {
       return false;
@@ -98,6 +107,25 @@ class XhtmlParagraphWalker {
   }
   static void XMLCALL chars_thunk(void* ud, const XML_Char* text, int len) {
     static_cast<XhtmlParagraphWalker*>(ud)->on_chars(text, len);
+  }
+  // Default-handler thunk for &...; entity references that expat
+  // doesn't have a DTD declaration for. Pass through lookupHtmlEntity
+  // (the same table ChapterHtmlSlimParser uses) and re-emit the
+  // UTF-8 substitution as character data.
+  static void XMLCALL default_thunk(void* ud, const XML_Char* s, int len) {
+    if (len >= 3 && s[0] == '&' && s[len - 1] == ';') {
+      const char* utf8 = lookupHtmlEntity(s, static_cast<size_t>(len));
+      auto* self = static_cast<XhtmlParagraphWalker*>(ud);
+      if (utf8 != nullptr) {
+        // Known entity: emit its UTF-8 value through the character handler.
+        self->on_chars(utf8, static_cast<int>(std::strlen(utf8)));
+      } else {
+        // Unknown entity: preserve the raw &...; so it round-trips visibly.
+        self->on_chars(s, len);
+      }
+    }
+    // Anything else (whitespace between tags, etc.) is silently dropped --
+    // expat already gave us the meaningful tokens via element/chars handlers.
   }
 
   // ---- tag classification ----

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -525,7 +525,21 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
       const std::string chapter_full_path =
           FsHelpers::normalisePath(book.getBasePath() + entry.href);
       XhtmlParagraphWalker walker(writer_sink, &ctx, &w, &book, chapter_full_path);
-      const bool parsed_ok = walker.feed(reinterpret_cast<const char*>(raw), raw_size, /*is_final=*/true);
+      // Feed the raw chapter bytes through expat in small chunks rather
+      // than one big XML_Parse(data, 26000, true). One-shot parsing
+      // makes expat double-buffer the entire input (~50 KB peak just
+      // for the parser) which routinely OOMs on device with a real-
+      // world heap: walker.feed used to fail at line 1 col 0 with
+      // XML_ERROR_NO_MEMORY before this. ChapterHtmlSlimParser uses the
+      // same chunking pattern via XML_GetBuffer.
+      constexpr size_t kFeedChunk = 2048;
+      bool parsed_ok = true;
+      for (size_t pos = 0; pos < raw_size && parsed_ok; pos += kFeedChunk) {
+        const size_t remaining = raw_size - pos;
+        const size_t chunk = remaining < kFeedChunk ? remaining : kFeedChunk;
+        const bool is_final = (pos + chunk) == raw_size;
+        parsed_ok = walker.feed(reinterpret_cast<const char*>(raw) + pos, chunk, is_final);
+      }
       // Flush whatever the walker buffered past its last paragraph
       // close (handles XHTML that ends without a closing </p>).
       const bool flushed_ok = walker.flush();

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -456,6 +456,20 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
   metadata.cover_href = book.getCoverItemHref();
   metadata.text_reference_href = book.getTextReferenceHref();
   metadata.css_files = book.getCssFiles();
+  // TOC entries: flat list with `level` carrying nesting. spine_index
+  // isn't stored on disk -- the reader resolves it from href at load
+  // time (matches BookMetadataCache::buildBookBin).
+  const int toc_count = book.getTocItemsCount();
+  metadata.toc.reserve(toc_count);
+  for (int ti = 0; ti < toc_count; ++ti) {
+    const auto src = book.getTocItem(ti);
+    CmbTocEntry dst;
+    dst.title = src.title;
+    dst.href = src.href;
+    dst.anchor = src.anchor;
+    dst.level = src.level;
+    metadata.toc.push_back(std::move(dst));
+  }
   metadata.spine.reserve(chapter_count);
   uint32_t cumulative = 0;
   for (int ci = 0; ci < chapter_count; ++ci) {

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -442,7 +442,12 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
 
   WriterSinkCtx ctx{&w, false};
 
+  // Collect spine hrefs as we walk so the writer can serialise them
+  // into the .cmb v2 metadata blob. Indexed by spine order (= the
+  // chapter index in .cmb), matching what BookMetadataCache expects.
   const int chapter_count = book.getSpineItemsCount();
+  std::vector<std::string> spine_hrefs;
+  spine_hrefs.reserve(chapter_count);
   for (int ci = 0; ci < chapter_count; ++ci) {
     const auto entry = book.getSpineItem(ci);
 
@@ -473,9 +478,10 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
     }
     std::free(raw);
     w.end_chapter();
+    spine_hrefs.push_back(entry.href);
   }
 
-  if (!w.finish(book.getTitle(), book.getAuthor())) {
+  if (!w.finish(book.getTitle(), book.getAuthor(), spine_hrefs)) {
     w.close();
     return false;
   }

--- a/lib/Cmb/CmbConverter.cpp
+++ b/lib/Cmb/CmbConverter.cpp
@@ -1,10 +1,12 @@
 #include "CmbConverter.h"
 
-#include <cctype>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <expat.h>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "CmbWriter.h"
 
@@ -12,171 +14,308 @@ namespace cmb {
 
 namespace {
 
-// Strip XHTML/HTML tags from a UTF-8 byte buffer and return the
-// resulting plain-text content. Single-pass, no regex, no expat
-// dependency. Handles:
-//   - Tags <foo> and </foo> -- skipped entirely (including attributes
-//     and self-closing forms like <br/>). Doesn't parse the tag name;
-//     just consumes characters until the matching '>'.
-//   - Comments <!-- ... --> -- skipped.
-//   - The common named entities (&amp;, &lt;, &gt;, &quot;, &apos;,
-//     &nbsp;) and numeric refs &#N; / &#xH;.
-//   - Whitespace collapse: any run of ASCII whitespace (space, tab,
-//     newline, CR, FF) becomes a single space. Leading + trailing
-//     whitespace is trimmed.
+// ===========================================================================
+// XhtmlParagraphWalker
+// ===========================================================================
 //
-// Phase A.C v0 limitation: paragraph boundaries (<p>, <div>, <h1..6>,
-// <br/>) are NOT preserved -- the whole chapter collapses into one
-// run of words separated by spaces. Acceptable for round-trip testing
-// the writer/reader; v1 of the converter splits on these boundaries.
-std::string strip_html_to_plain_text(std::string_view src) {
-  std::string out;
-  // Reserve a guess: stripped text is usually 60-80% of source size.
-  out.reserve(src.size() * 3 / 4);
+// Streams XHTML through expat and emits one CmbParagraph per
+// paragraph-boundary tag (`<p>`, `<div>`, `<h1>` .. `<h6>`, `<li>`,
+// `<blockquote>`) plus on `<br/>` boundaries. Inline-style tags
+// (`<b>` / `<strong>`, `<i>` / `<em>`, `<u>`, `<s>` / `<strike>`)
+// build style runs inside the current paragraph; the runs persist
+// inside `CmbParagraph::runs` as non-overlapping `{start, length, mask}`
+// triples.
+//
+// Heading level is captured from the source tag name: `<h1>` -> 1,
+// `<h2>` -> 2, etc. Anchor ids are captured from the first `id`
+// attribute encountered within a paragraph (paragraph-boundary tag
+// OR a wrapping `<span>` / `<a>`).
+//
+// `<img>` and other media tags are deliberately ignored in this
+// commit -- they need an image ref resolver pass (to look up the
+// EPUB ZIP entry, get the local-file-header offset, register in the
+// .cmb image table) that arrives in the next checkpoint.
+//
+// The output sink is a std::function<bool(const CmbParagraph&)> that
+// returns false to stop the parse (e.g. on writer I/O failure).
+class XhtmlParagraphWalker {
+ public:
+  using Sink = bool (*)(void* ctx, const CmbParagraph&);
 
-  const size_t n = src.size();
-  size_t i = 0;
-  bool last_was_space = true;  // emits no leading whitespace
+  XhtmlParagraphWalker(Sink sink, void* ctx) : sink_(sink), ctx_(ctx) {}
 
-  auto emit_char = [&](char c) {
-    if (c == '\0') return;
-    if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f') {
-      if (!last_was_space) {
-        out.push_back(' ');
-        last_was_space = true;
+  // Feed a chunk of XHTML bytes through expat. Returns false on
+  // expat parse error or sink-rejection; partial state from previous
+  // chunks is retained across calls.
+  bool feed(const char* data, size_t size, bool is_final) {
+    if (parser_ == nullptr) {
+      parser_ = XML_ParserCreate(nullptr);
+      if (parser_ == nullptr) return false;
+      XML_SetUserData(parser_, this);
+      XML_SetElementHandler(parser_, &XhtmlParagraphWalker::start_thunk, &XhtmlParagraphWalker::end_thunk);
+      XML_SetCharacterDataHandler(parser_, &XhtmlParagraphWalker::chars_thunk);
+    }
+    if (XML_Parse(parser_, data, static_cast<int>(size), is_final ? 1 : 0) == XML_STATUS_ERROR) {
+      return false;
+    }
+    return !sink_failed_;
+  }
+
+  // Emit any leftover paragraph the walker has buffered (e.g. when
+  // the source XHTML doesn't close its last <p> before EOF).
+  bool flush() {
+    return emit_pending();
+  }
+
+  ~XhtmlParagraphWalker() {
+    if (parser_ != nullptr) XML_ParserFree(parser_);
+  }
+
+ private:
+  // ---- expat thunks ----
+
+  static void XMLCALL start_thunk(void* ud, const XML_Char* name, const XML_Char** atts) {
+    static_cast<XhtmlParagraphWalker*>(ud)->on_start(name, atts);
+  }
+  static void XMLCALL end_thunk(void* ud, const XML_Char* name) {
+    static_cast<XhtmlParagraphWalker*>(ud)->on_end(name);
+  }
+  static void XMLCALL chars_thunk(void* ud, const XML_Char* text, int len) {
+    static_cast<XhtmlParagraphWalker*>(ud)->on_chars(text, len);
+  }
+
+  // ---- tag classification ----
+
+  static bool tag_eq(const char* a, const char* b) { return std::strcmp(a, b) == 0; }
+
+  static bool is_paragraph_boundary(const char* name) {
+    return tag_eq(name, "p") || tag_eq(name, "div") || tag_eq(name, "li") || tag_eq(name, "blockquote") ||
+           tag_eq(name, "h1") || tag_eq(name, "h2") || tag_eq(name, "h3") || tag_eq(name, "h4") ||
+           tag_eq(name, "h5") || tag_eq(name, "h6");
+  }
+  static uint8_t heading_level_for_tag(const char* name) {
+    if (name[0] == 'h' && name[1] >= '1' && name[1] <= '6' && name[2] == '\0') {
+      return static_cast<uint8_t>(name[1] - '0');
+    }
+    return 0;
+  }
+  static bool is_bold_tag(const char* name) { return tag_eq(name, "b") || tag_eq(name, "strong"); }
+  static bool is_italic_tag(const char* name) { return tag_eq(name, "i") || tag_eq(name, "em"); }
+  static bool is_underline_tag(const char* name) { return tag_eq(name, "u") || tag_eq(name, "ins"); }
+  static bool is_strike_tag(const char* name) { return tag_eq(name, "s") || tag_eq(name, "strike") || tag_eq(name, "del"); }
+  static bool is_hard_break_tag(const char* name) { return tag_eq(name, "br"); }
+
+  // ---- event handlers ----
+
+  void on_start(const char* name, const XML_Char** atts) {
+    // Capture id attribute if the current paragraph doesn't already
+    // have one. First-id-wins keeps the behaviour stable for nested
+    // wrappers like <a id="..."> <span ...>...</span> </a>.
+    if (current_anchor_.empty()) {
+      for (int i = 0; atts && atts[i]; i += 2) {
+        if (tag_eq(atts[i], "id")) {
+          current_anchor_ = atts[i + 1];
+          break;
+        }
       }
+    }
+
+    if (is_paragraph_boundary(name)) {
+      // Boundary opens a new paragraph -- flush whatever was in
+      // progress (handles the unclosed-<p> + <p>-as-sibling pattern).
+      emit_pending();
+      pending_heading_ = heading_level_for_tag(name);
       return;
     }
-    out.push_back(c);
-    last_was_space = false;
-  };
-
-  auto emit_codepoint = [&](uint32_t cp) {
-    // Re-encode codepoint as UTF-8 bytes. Common case: ASCII falls
-    // through emit_char's whitespace handling cleanly.
-    if (cp < 0x80) {
-      emit_char(static_cast<char>(cp));
-    } else if (cp < 0x800) {
-      out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
-      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-      last_was_space = false;
-    } else if (cp < 0x10000) {
-      out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
-      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-      last_was_space = false;
-    } else if (cp < 0x110000) {
-      out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
-      out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
-      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
-      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
-      last_was_space = false;
+    if (is_hard_break_tag(name)) {
+      emit_pending();
+      return;
     }
-    // Codepoints >= 0x110000 are illegal -- silently drop.
-  };
+    if (is_bold_tag(name)) {
+      ++bold_depth_;
+      return;
+    }
+    if (is_italic_tag(name)) {
+      ++italic_depth_;
+      return;
+    }
+    if (is_underline_tag(name)) {
+      ++underline_depth_;
+      return;
+    }
+    if (is_strike_tag(name)) {
+      ++strike_depth_;
+      return;
+    }
+    // <img>, <hr>, etc. are intentionally not handled here -- left for
+    // a follow-up image-ref + block emitter that needs more EPUB
+    // context than the walker has.
+  }
 
-  while (i < n) {
-    const char c = src[i];
-    if (c == '<') {
-      // Comment? <!-- ... -->
-      if (i + 3 < n && src[i + 1] == '!' && src[i + 2] == '-' && src[i + 3] == '-') {
-        // Scan for "-->"
-        size_t j = i + 4;
-        while (j + 2 < n && !(src[j] == '-' && src[j + 1] == '-' && src[j + 2] == '>')) {
-          ++j;
-        }
-        i = (j + 2 < n) ? j + 3 : n;
-        // Treat comment as a separator (emit space so adjacent text
-        // doesn't run together when a comment splits it).
+  void on_end(const char* name) {
+    if (is_paragraph_boundary(name)) {
+      emit_pending();
+      return;
+    }
+    if (is_bold_tag(name)) {
+      if (bold_depth_ > 0) --bold_depth_;
+      return;
+    }
+    if (is_italic_tag(name)) {
+      if (italic_depth_ > 0) --italic_depth_;
+      return;
+    }
+    if (is_underline_tag(name)) {
+      if (underline_depth_ > 0) --underline_depth_;
+      return;
+    }
+    if (is_strike_tag(name)) {
+      if (strike_depth_ > 0) --strike_depth_;
+      return;
+    }
+  }
+
+  void on_chars(const XML_Char* text, int len) {
+    if (len <= 0) return;
+    // Skip leading whitespace when the paragraph is fresh -- avoids
+    // synthesising a "paragraph" of just whitespace between tags.
+    size_t start = 0;
+    if (current_text_.empty()) {
+      while (start < static_cast<size_t>(len) && is_xml_space(text[start])) ++start;
+      if (start == static_cast<size_t>(len)) return;
+    }
+
+    const size_t before = current_text_.size();
+    const uint8_t mask = current_style_mask();
+    // Collapse runs of whitespace into a single space character as we
+    // append. Cheap normalisation that matches how readers will lay
+    // out the text anyway.
+    bool last_was_space = !current_text_.empty() && current_text_.back() == ' ';
+    for (size_t i = start; i < static_cast<size_t>(len); ++i) {
+      const char c = text[i];
+      if (is_xml_space(c)) {
         if (!last_was_space) {
-          out.push_back(' ');
+          current_text_.push_back(' ');
           last_was_space = true;
         }
-        continue;
+      } else {
+        current_text_.push_back(c);
+        last_was_space = false;
       }
-      // Generic tag: skip to matching '>'. Doesn't try to parse the
-      // tag; intentionally permissive on malformed HTML.
-      while (i < n && src[i] != '>') ++i;
-      if (i < n) ++i;  // consume '>'
-      // Tags act as soft separators between text runs.
-      if (!last_was_space) {
-        out.push_back(' ');
-        last_was_space = true;
-      }
-      continue;
     }
-    if (c == '&') {
-      // Entity. Common named refs + numeric refs.
-      // Scan for terminating ';' (cap at 8 chars to stay safe on
-      // malformed input).
-      size_t end = i + 1;
-      while (end < n && end < i + 10 && src[end] != ';' && src[end] != '<' && src[end] != '&') {
-        ++end;
-      }
-      if (end < n && src[end] == ';') {
-        const std::string_view entity = src.substr(i + 1, end - i - 1);
-        if (entity == "amp") {
-          emit_char('&');
-        } else if (entity == "lt") {
-          emit_char('<');
-        } else if (entity == "gt") {
-          emit_char('>');
-        } else if (entity == "quot") {
-          emit_char('"');
-        } else if (entity == "apos") {
-          emit_char('\'');
-        } else if (entity == "nbsp") {
-          emit_char(' ');
-        } else if (entity.size() >= 2 && entity[0] == '#') {
-          // Numeric ref: &#N; (decimal) or &#xH; / &#XH; (hex).
-          uint32_t cp = 0;
-          if (entity[1] == 'x' || entity[1] == 'X') {
-            for (size_t k = 2; k < entity.size(); ++k) {
-              const char d = entity[k];
-              if (d >= '0' && d <= '9') {
-                cp = cp * 16 + static_cast<uint32_t>(d - '0');
-              } else if (d >= 'a' && d <= 'f') {
-                cp = cp * 16 + static_cast<uint32_t>(d - 'a' + 10);
-              } else if (d >= 'A' && d <= 'F') {
-                cp = cp * 16 + static_cast<uint32_t>(d - 'A' + 10);
-              } else {
-                cp = 0;
-                break;
-              }
-            }
-          } else {
-            for (size_t k = 1; k < entity.size(); ++k) {
-              const char d = entity[k];
-              if (d < '0' || d > '9') {
-                cp = 0;
-                break;
-              }
-              cp = cp * 10 + static_cast<uint32_t>(d - '0');
-            }
-          }
-          if (cp != 0) emit_codepoint(cp);
+
+    if (mask != 0) {
+      const size_t added = current_text_.size() - before;
+      if (added > 0) {
+        // Extend the last run if it ends at the same byte position
+        // AND carries the same style mask. Otherwise start a fresh
+        // run at `before`.
+        if (!current_runs_.empty() && current_runs_.back().style == mask &&
+            static_cast<size_t>(current_runs_.back().start) + current_runs_.back().length == before) {
+          current_runs_.back().length = static_cast<uint16_t>(current_runs_.back().length + added);
+        } else if (before <= 0xFFFF && added <= 0xFFFF) {
+          CmbStyleRun r;
+          r.start = static_cast<uint16_t>(before);
+          r.length = static_cast<uint16_t>(added);
+          r.style = mask;
+          current_runs_.push_back(r);
         }
-        // Unknown named entity -- drop silently. (Could fall back to
-        // emitting the raw '&...;' but that confuses downstream
-        // text-content callers more than dropping does.)
-        i = end + 1;
-        continue;
+        // If a paragraph's text length exceeds 64 KB, run-position
+        // overflows the u16 fields. We drop the affected run (the
+        // text itself is still kept). This is fine for the first
+        // converter version; production EPUBs don't have 64 KB
+        // single-paragraph runs.
       }
-      // No terminating ';' -- treat '&' as literal.
-      emit_char('&');
-      ++i;
-      continue;
     }
-    emit_char(c);
-    ++i;
   }
 
-  // Trim trailing whitespace (we always emit a single space for runs,
-  // so at most one trailing space to peel off).
-  if (!out.empty() && out.back() == ' ') {
-    out.pop_back();
+  // ---- state helpers ----
+
+  bool emit_pending() {
+    // Trim trailing whitespace (we always collapse internal whitespace
+    // to a single space; at most one trailing space to peel).
+    while (!current_text_.empty() && current_text_.back() == ' ') {
+      current_text_.pop_back();
+    }
+    if (current_text_.empty() && current_anchor_.empty() && pending_heading_ == 0) {
+      // Nothing accumulated -- common when paragraph-boundary tags
+      // wrap empty / whitespace-only spans. No paragraph emitted.
+      reset_pending();
+      return true;
+    }
+
+    CmbParagraph p;
+    p.type = kCmbBlockText;
+    p.text = std::move(current_text_);
+    p.runs = std::move(current_runs_);
+    p.heading_level = pending_heading_;
+    p.anchor_id = std::move(current_anchor_);
+    // alignment defaults to kCmbAlignDefault; CSS-driven alignment is
+    // a future enhancement (would require a CSS parse pass).
+
+    reset_pending();
+    if (sink_ != nullptr) {
+      if (!sink_(ctx_, p)) {
+        sink_failed_ = true;
+        return false;
+      }
+    }
+    return true;
   }
-  return out;
+
+  void reset_pending() {
+    current_text_.clear();
+    current_runs_.clear();
+    current_anchor_.clear();
+    pending_heading_ = 0;
+  }
+
+  uint8_t current_style_mask() const {
+    uint8_t m = 0;
+    if (bold_depth_ > 0) m |= kCmbStyleBold;
+    if (italic_depth_ > 0) m |= kCmbStyleItalic;
+    if (underline_depth_ > 0) m |= kCmbStyleUnderline;
+    if (strike_depth_ > 0) m |= kCmbStyleStrikethrough;
+    return m;
+  }
+
+  static bool is_xml_space(char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f'; }
+
+  // ---- members ----
+
+  XML_Parser parser_ = nullptr;
+  Sink sink_ = nullptr;
+  void* ctx_ = nullptr;
+  bool sink_failed_ = false;
+
+  // Per-paragraph accumulator.
+  std::string current_text_;
+  std::vector<CmbStyleRun> current_runs_;
+  std::string current_anchor_;
+  uint8_t pending_heading_ = 0;
+
+  // Open-depth counters for inline-style tags.
+  int bold_depth_ = 0;
+  int italic_depth_ = 0;
+  int underline_depth_ = 0;
+  int strike_depth_ = 0;
+};
+
+// Adapter that lets the walker push paragraphs straight into a
+// CmbWriter without a std::function indirection.
+struct WriterSinkCtx {
+  CmbWriter* writer;
+  bool any_failure;
+};
+
+bool writer_sink(void* ctx_v, const CmbParagraph& p) {
+  auto* ctx = static_cast<WriterSinkCtx*>(ctx_v);
+  if (ctx->any_failure) return false;
+  if (!ctx->writer->write_paragraph(p)) {
+    ctx->any_failure = true;
+    return false;
+  }
+  return true;
 }
 
 }  // namespace
@@ -184,6 +323,8 @@ std::string strip_html_to_plain_text(std::string_view src) {
 bool convert_epub_to_cmb(Epub& book, const char* output_path) {
   CmbWriter w;
   if (!w.open(output_path)) return false;
+
+  WriterSinkCtx ctx{&w, false};
 
   const int chapter_count = book.getSpineItemsCount();
   for (int ci = 0; ci < chapter_count; ++ci) {
@@ -194,24 +335,21 @@ bool convert_epub_to_cmb(Epub& book, const char* output_path) {
 
     w.begin_chapter();
     if (raw != nullptr && raw_size > 0) {
-      // Phase A.C v0: one paragraph per chapter containing all the
-      // stripped-of-tags text. Subsequent commits split on <p>/<div>/<h*>
-      // boundaries and capture inline styling.
-      std::string text = strip_html_to_plain_text(
-          std::string_view{reinterpret_cast<const char*>(raw), raw_size});
-      if (!text.empty()) {
-        CmbParagraph p;
-        p.type = kCmbBlockText;
-        p.text = std::move(text);
-        if (!w.write_paragraph(p)) {
-          // Write failure on this paragraph -- skip rest of chapter
-          // (end_chapter still writes the descriptor table for what
-          // we did emit) but treat the overall conversion as failed.
-          std::free(raw);
-          w.end_chapter();
-          w.close();
-          return false;
-        }
+      // Fresh walker per chapter -- expat carries some per-document
+      // state (DTD declarations, namespace tables) we don't want to
+      // bleed across spine items.
+      XhtmlParagraphWalker walker(writer_sink, &ctx);
+      const bool parsed_ok = walker.feed(reinterpret_cast<const char*>(raw), raw_size, /*is_final=*/true);
+      // Flush whatever the walker buffered past its last paragraph
+      // close (handles XHTML that ends without a closing </p>).
+      const bool flushed_ok = walker.flush();
+      if (!parsed_ok || !flushed_ok || ctx.any_failure) {
+        // Parse error / writer error -- finalize the chapter so the
+        // descriptor table is consistent, then bail.
+        std::free(raw);
+        w.end_chapter();
+        w.close();
+        return false;
       }
     }
     std::free(raw);

--- a/lib/Cmb/CmbConverter.h
+++ b/lib/Cmb/CmbConverter.h
@@ -24,9 +24,9 @@
 // font/margin settings -- the produced .cmb is layout-independent
 // per the format design.
 
-#include <string>
+#include <Epub.h>
 
-#include "../Epub/Epub.h"
+#include <string>
 
 namespace cmb {
 

--- a/lib/Cmb/CmbConverter.h
+++ b/lib/Cmb/CmbConverter.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// CmbConverter -- EPUB -> .cmb single-pass conversion.
+//
+// Wraps an opened `Epub` and emits a .cmb file alongside it. Uses
+// `CmbWriter` for the on-disk format and `Epub::readItemContentsToBytes`
+// to pull each spine item's raw XHTML out of the EPUB ZIP.
+//
+// Phase A.C v0 (this checkpoint): minimal text extraction.
+//   - One CmbParagraph per spine chapter, containing the chapter's
+//     entire stripped-of-tags text as a single kCmbBlockText record.
+//   - Metadata: title + author from Epub::getTitle() / getAuthor().
+//   - No image refs, no inline-style runs, no anchor table, no
+//     per-paragraph splitting on <p>/<div>/<h*>.
+//
+// Phase A.C v1 (next checkpoint): proper paragraph segmentation via
+// the expat parser + entity decoding hooks.
+//
+// Phase A.C v2: inline-style runs (bold/italic/underline), heading
+// levels, anchor id collection for in-book link nav.
+//
+// The Epub passed in MUST already be loaded (`Epub::load(...)` called
+// successfully). Conversion does not depend on the layout-specific
+// font/margin settings -- the produced .cmb is layout-independent
+// per the format design.
+
+#include <string>
+
+#include "../Epub/Epub.h"
+
+namespace cmb {
+
+// Convert `book` to a .cmb file at `output_path`. Returns true on
+// success, false on any I/O or format error along the way; on false
+// the partial output file may be left on disk in an unspecified
+// state -- callers should treat it as missing.
+//
+// The book's title + author become the .cmb metadata. Spine order
+// is preserved as chapter order in the output (chapter index i in
+// the .cmb corresponds to spine index i in the EPUB).
+bool convert_epub_to_cmb(Epub& book, const char* output_path);
+
+}  // namespace cmb

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -64,17 +64,20 @@ inline constexpr uint8_t kCmbMagic[4] = {'C', 'M', 'B', '1'};
 // Version history:
 //   1  -- initial layout (header + chapter table + image refs + anchors
 //         + metadata{title, author}). Internal-only; never shipped.
-//   2  -- metadata blob extended with spine entry hrefs so the reader
-//         can populate Epub::BookMetadataCache from .cmb without
-//         walking the EPUB ZIP central directory + content.opf.
-//         Layout: title_len/title, author_len/author, spine_count,
-//         spine_entries[{href_len, href}], toc_count (stub for now).
-//   3  -- (planned) adds TOC entries (title + href + anchor + level
-//         per entry) so chapter selection UI works from .cmb alone.
-//   4  -- (planned) adds cover_thumb_offset + thumb table for pre-baked
-//         cover BMPs at all device-rendered sizes. See companion task
-//         "Pre-bake cover thumbs inside .cmb file".
-inline constexpr uint16_t kCmbVersion = 2;
+//   2  -- metadata blob extended with spine entry hrefs.
+//   3  -- the full BookMetadataCache set: spine entries gain
+//         cumulative_size (so the reader skips the per-entry ZIP
+//         inflated-size query during Epub::load -> buildBookBin),
+//         plus language / cover_href / text_reference_href / css
+//         files list at the top of the metadata blob. Skipping those
+//         queries is the actual ~30 KB cold-open heap win on big
+//         books.
+//   4  -- (planned) TOC entries (title + href + anchor + level per
+//         entry) so chapter selection UI works from .cmb alone.
+//   5  -- (planned) cover_thumb_offset + thumb table for pre-baked
+//         cover BMPs at all device-rendered sizes. See companion
+//         task "Pre-bake cover thumbs inside .cmb file".
+inline constexpr uint16_t kCmbVersion = 3;
 
 // ---------------------------------------------------------------------------
 // Header (32 bytes, fixed)
@@ -304,6 +307,59 @@ struct CmbStyleRun {
   uint16_t start = 0;   // byte offset into CmbParagraph::text
   uint16_t length = 0;  // byte length of the styled span
   uint8_t style = 0;    // kCmbStyle* bitmask
+};
+
+// ---------------------------------------------------------------------------
+// In-memory book metadata (v3)
+// ---------------------------------------------------------------------------
+//
+// Mirrors the subset of EPUB metadata that Epub::BookMetadataCache
+// holds. Populated by the converter from the open EPUB; consumed by
+// the reader to short-circuit Epub::load's ZIP-central-dir +
+// content.opf parse.
+//
+// On-disk layout (lives inside the metadata blob region pointed at by
+// header.meta_offset):
+//
+//   title_len:u16, title:bytes
+//   author_len:u16, author:bytes
+//   language_len:u16, language:bytes
+//   cover_href_len:u16, cover_href:bytes
+//   text_reference_href_len:u16, text_reference_href:bytes
+//   spine_count:u16
+//   spine_entries[spine_count]:
+//     href_len:u16, href:bytes
+//     cumulative_size:u32       -- sum of inflated sizes through this spine
+//                                  item (matches BookMetadataCache::SpineEntry)
+//   css_count:u16
+//   css_files[css_count]: { path_len:u16, path:bytes }
+//   toc_count:u16                -- 0 in v3; v4 populates the entries
+
+struct CmbSpineEntry {
+  std::string href;
+  // Sum of inflated ZIP-entry sizes through and INCLUDING this spine
+  // item. Used by the reader for reading-progress math + chapter
+  // pre-allocation. Set during conversion via Epub::getItemSize.
+  uint32_t cumulative_size = 0;
+};
+
+struct CmbBookMetadata {
+  std::string title;
+  std::string author;
+  std::string language;
+  // EPUB-relative href of the cover image item (e.g. "OEBPS/cover.jpg").
+  // Empty when the EPUB lacks a cover.
+  std::string cover_href;
+  // The "main text starts here" reference from the OPF guide (legacy
+  // EPUB 2). Empty for most modern EPUBs.
+  std::string text_reference_href;
+  // Spine entries in spine order; size must match the converter's
+  // chapter_count (one entry per spine item).
+  std::vector<CmbSpineEntry> spine;
+  // CSS file paths (EPUB-relative) found in the OPF manifest. The
+  // reader pulls these from the EPUB ZIP at first open to populate
+  // its CSS rule cache.
+  std::vector<std::string> css_files;
 };
 
 struct CmbParagraph {

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -63,11 +63,18 @@ inline constexpr uint8_t kCmbMagic[4] = {'C', 'M', 'B', '1'};
 
 // Version history:
 //   1  -- initial layout (header + chapter table + image refs + anchors
-//         + metadata). Per-chapter content is opaque blob.
-//   2  -- (planned) adds cover_thumb_offset + thumb table for pre-baked
+//         + metadata{title, author}). Internal-only; never shipped.
+//   2  -- metadata blob extended with spine entry hrefs so the reader
+//         can populate Epub::BookMetadataCache from .cmb without
+//         walking the EPUB ZIP central directory + content.opf.
+//         Layout: title_len/title, author_len/author, spine_count,
+//         spine_entries[{href_len, href}], toc_count (stub for now).
+//   3  -- (planned) adds TOC entries (title + href + anchor + level
+//         per entry) so chapter selection UI works from .cmb alone.
+//   4  -- (planned) adds cover_thumb_offset + thumb table for pre-baked
 //         cover BMPs at all device-rendered sizes. See companion task
 //         "Pre-bake cover thumbs inside .cmb file".
-inline constexpr uint16_t kCmbVersion = 1;
+inline constexpr uint16_t kCmbVersion = 2;
 
 // ---------------------------------------------------------------------------
 // Header (32 bytes, fixed)

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -158,6 +158,24 @@ inline constexpr uint16_t kCmbSpacingDefault = 0xFFFF;
 inline constexpr uint16_t kCmbNoImage = 0xFFFF;
 
 // ---------------------------------------------------------------------------
+// Alignment values for CmbParagraph::alignment
+// ---------------------------------------------------------------------------
+
+inline constexpr uint8_t kCmbAlignLeft = 0;
+inline constexpr uint8_t kCmbAlignCenter = 1;
+inline constexpr uint8_t kCmbAlignRight = 2;
+inline constexpr uint8_t kCmbAlignJustify = 3;
+
+// ---------------------------------------------------------------------------
+// Style mask bits for CmbStyleRun::style
+// ---------------------------------------------------------------------------
+
+inline constexpr uint8_t kCmbStyleBold = 0x01;
+inline constexpr uint8_t kCmbStyleItalic = 0x02;
+inline constexpr uint8_t kCmbStyleUnderline = 0x04;
+inline constexpr uint8_t kCmbStyleStrikethrough = 0x08;
+
+// ---------------------------------------------------------------------------
 // Little-endian serialization helpers
 // ---------------------------------------------------------------------------
 //
@@ -253,22 +271,54 @@ inline bool cmb_magic_matches(const uint8_t magic[4]) {
 // Payload layouts (subject to extension in subsequent commits):
 //
 //   kCmbBlockText:
+//     alignment:u8              -- kCmbAlignLeft/Center/Right/Justify/Default
+//     heading_level:u8          -- 0 = normal, 1..6 = h1..h6
 //     text_len:u32
 //     text:bytes[text_len]      -- UTF-8
+//     run_count:u16
+//     runs[run_count]:
+//       start:u16   -- byte offset into text where the run begins
+//       length:u16  -- byte length of the run
+//       style:u8    -- kCmbStyleBold | kCmbStyleItalic | kCmbStyleUnderline | ...
+//     anchor_id_len:u8
+//     anchor_id:bytes[anchor_id_len]
 //
 //   kCmbBlockImage:
 //     image_key:u16             -- index into image ref table
+//     anchor_id_len:u8
+//     anchor_id:bytes[anchor_id_len]
 //
 //   kCmbBlockHr, kCmbBlockPageBreak:
 //     (empty payload)
+
+// One styled run inside a kCmbBlockText paragraph. Encodes
+// non-overlapping spans of bold/italic/underline/strikethrough.
+struct CmbStyleRun {
+  uint16_t start = 0;   // byte offset into CmbParagraph::text
+  uint16_t length = 0;  // byte length of the styled span
+  uint8_t style = 0;    // kCmbStyle* bitmask
+};
 
 struct CmbParagraph {
   uint8_t type = kCmbBlockText;
   // For kCmbBlockText: UTF-8 paragraph contents. Empty for non-text.
   std::string text;
+  // For kCmbBlockText: non-overlapping styled byte ranges within text.
+  // Empty when the paragraph has no inline styling.
+  std::vector<CmbStyleRun> runs;
+  // For kCmbBlockText: paragraph-level alignment. kCmbAlignDefault
+  // means "use the reader's default" (justify under most settings).
+  uint8_t alignment = kCmbAlignDefault;
+  // For kCmbBlockText: 0 for body text, 1..6 for h1..h6.
+  uint8_t heading_level = 0;
   // For kCmbBlockImage: index into the file's image-ref table.
   // kCmbNoImage when not an image block.
   uint16_t image_key = kCmbNoImage;
+  // For any block type: the HTML id attribute of the source element,
+  // if any. The converter records this per-paragraph for the global
+  // anchor table (id -> para_index) used by in-book link nav.
+  // Empty when no id attribute was present.
+  std::string anchor_id;
 };
 
 }  // namespace cmb

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -72,12 +72,13 @@ inline constexpr uint8_t kCmbMagic[4] = {'C', 'M', 'B', '1'};
 //         files list at the top of the metadata blob. Skipping those
 //         queries is the actual ~30 KB cold-open heap win on big
 //         books.
-//   4  -- (planned) TOC entries (title + href + anchor + level per
-//         entry) so chapter selection UI works from .cmb alone.
+//   4  -- TOC entries (title + href + anchor + level per entry) so
+//         chapter selection UI works from .cmb alone. Replaces v3's
+//         toc_count:u16 = 0 stub.
 //   5  -- (planned) cover_thumb_offset + thumb table for pre-baked
 //         cover BMPs at all device-rendered sizes. See companion
 //         task "Pre-bake cover thumbs inside .cmb file".
-inline constexpr uint16_t kCmbVersion = 3;
+inline constexpr uint16_t kCmbVersion = 4;
 
 // ---------------------------------------------------------------------------
 // Header (32 bytes, fixed)
@@ -333,7 +334,17 @@ struct CmbStyleRun {
 //                                  item (matches BookMetadataCache::SpineEntry)
 //   css_count:u16
 //   css_files[css_count]: { path_len:u16, path:bytes }
-//   toc_count:u16                -- 0 in v3; v4 populates the entries
+//   toc_count:u16
+//   toc_entries[toc_count]:
+//     title_len:u16, title:bytes
+//     href_len:u16, href:bytes    -- EPUB-relative path; resolved to
+//                                    spine_index at load time by
+//                                    matching against the spine table
+//     anchor_len:u16, anchor:bytes -- fragment portion of the TOC link
+//                                    (the part after '#'); empty when
+//                                    the TOC entry points at a whole
+//                                    spine item
+//     level:u8                    -- nesting depth (1 = top-level)
 
 struct CmbSpineEntry {
   std::string href;
@@ -341,6 +352,18 @@ struct CmbSpineEntry {
   // item. Used by the reader for reading-progress math + chapter
   // pre-allocation. Set during conversion via Epub::getItemSize.
   uint32_t cumulative_size = 0;
+};
+
+// TOC tree entry. The on-disk format is FLAT -- nesting is expressed
+// by `level` (e.g. level=1 is a top-level entry, level=2 nested
+// under the previous level=1, etc.). spine_index isn't stored on
+// disk; the reader resolves it from `href` by linear-scanning the
+// spine table at load time (matches BookMetadataCache::buildBookBin).
+struct CmbTocEntry {
+  std::string title;
+  std::string href;
+  std::string anchor;
+  uint8_t level = 1;
 };
 
 struct CmbBookMetadata {
@@ -360,6 +383,9 @@ struct CmbBookMetadata {
   // reader pulls these from the EPUB ZIP at first open to populate
   // its CSS rule cache.
   std::vector<std::string> css_files;
+  // Flat TOC entries; nesting via the level field. Empty when the
+  // EPUB lacks a TOC or the converter couldn't parse one.
+  std::vector<CmbTocEntry> toc;
 };
 
 struct CmbParagraph {

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -1,0 +1,234 @@
+#pragma once
+
+// CMB (CrumBLE Book) -- pre-processed single-file binary format for fast
+// cold book-open + reduced heap pressure under BLE. Companion to .pxc
+// (which caches pre-rendered page bitmaps); .cmb caches the upstream
+// stuff -- chapter index, paragraph data, image refs, anchors, metadata.
+//
+// Designed by CrumBLE; format owned by us. Inspired by the patterns in
+// microreader's MrbFormat.h (CidVonHighwind/microreader) -- chapter
+// table in RAM with per-paragraph index seeked on demand, image refs
+// stored as ZIP local-header offsets so the reader can pull image
+// bytes from the original EPUB without walking the ZIP central
+// directory. We do NOT copy their bytes; magic is "CMB1", versioning
+// is ours.
+//
+// File layout (all multi-byte values little-endian):
+//
+//   [Header 32 bytes]
+//   [Per-chapter content blobs ............ variable]
+//   [Per-chapter descriptor tables ........ chapter_count x ND entries]
+//   [Chapter table ........................ chapter_count x 16 bytes]
+//   [Image ref table ...................... image_count   x  8 bytes]
+//   [Anchor table ......................... variable]
+//   [Metadata + TOC blobs ................. variable]
+//
+// Per-chapter content blob layout (inside the byte range a chapter's
+// table entry points at): a series of TAGGED records, each prefixed by
+// a 1-byte type tag + a 2-byte length-of-payload, followed by that many
+// bytes of type-specific data. Type tags are extensible -- new block
+// kinds (page break, footnote, etc.) can be added in future versions
+// without breaking older readers (they SKIP unknown tags using the
+// length prefix). See kCmbBlockType* constants below.
+//
+// Per-chapter descriptor table (written immediately after the chapter's
+// last paragraph blob):
+//   N x { file_offset(u32), char_offset(u32) }
+//   - file_offset: absolute byte position of the Nth block record in
+//     the file. Allows O(1) random access to any paragraph + accurate
+//     char-based reading progress without reading any block data.
+//   - char_offset: cumulative UTF-8 bytes of text BEFORE this block.
+//
+// The per-chapter descriptor table is INDEXED in the chapter table
+// (para_table_offset) but is NOT loaded into RAM on open() -- the
+// reader seeks the right table entry on demand. This is the win that
+// keeps a 377-spine-item book's open() cost at ~5 KB instead of
+// ~136 KB.
+
+#include <cstdint>
+#include <cstring>
+
+namespace cmb {
+
+// ---------------------------------------------------------------------------
+// Magic + version
+// ---------------------------------------------------------------------------
+// "CMB1" intentionally avoids "MRB" (microreader) and "CPB" (CrossPoint
+// generic) collisions. The trailing digit is the format generation; the
+// 16-bit version field below tracks per-generation revisions.
+
+inline constexpr uint8_t kCmbMagic[4] = {'C', 'M', 'B', '1'};
+
+// Version history:
+//   1  -- initial layout (header + chapter table + image refs + anchors
+//         + metadata). Per-chapter content is opaque blob.
+//   2  -- (planned) adds cover_thumb_offset + thumb table for pre-baked
+//         cover BMPs at all device-rendered sizes. See companion task
+//         "Pre-bake cover thumbs inside .cmb file".
+inline constexpr uint16_t kCmbVersion = 1;
+
+// ---------------------------------------------------------------------------
+// Header (32 bytes, fixed)
+// ---------------------------------------------------------------------------
+//
+// Designed at exactly 32 bytes so static_assert below catches accidental
+// drift on any compiler. Any future fields will land in a fresh
+// extension region pointed to by meta_offset until a version bump
+// justifies extending the fixed header.
+
+struct CmbHeader {
+  uint8_t magic[4];           // "CMB1"
+  uint16_t version;           // kCmbVersion
+  uint16_t flags;             // reserved for future use; writers SHOULD set to 0
+  uint32_t paragraph_count;   // total tagged-block records across all chapters
+  uint16_t chapter_count;
+  uint16_t image_count;
+  uint32_t anchor_offset;     // file offset of anchor table (id -> para_index)
+  uint32_t chapter_offset;    // file offset of chapter table
+  uint32_t image_offset;      // file offset of image ref table
+  uint32_t meta_offset;       // file offset of metadata + TOC blob region
+};
+static_assert(sizeof(CmbHeader) == 32, "CmbHeader must be exactly 32 bytes");
+
+// ---------------------------------------------------------------------------
+// Chapter table entry (16 bytes each)
+// ---------------------------------------------------------------------------
+
+struct CmbChapterEntry {
+  uint32_t para_table_offset;  // file offset of the per-chapter descriptor table
+  uint32_t reserved0;          // unused, write 0
+  uint16_t paragraph_count;    // number of tagged-block records in this chapter
+  uint16_t reserved1;          // unused, write 0
+  uint32_t char_count;         // total UTF-8 bytes of text in the chapter
+};
+static_assert(sizeof(CmbChapterEntry) == 16, "CmbChapterEntry must be exactly 16 bytes");
+
+// ---------------------------------------------------------------------------
+// Image reference entry (8 bytes each)
+// ---------------------------------------------------------------------------
+//
+// width / height are EPUB-declared (from <img width="..." height="...">
+// or equivalent). Most EPUBs don't declare them, in which case the
+// writer leaves them at 0 and the reader resolves the actual dimensions
+// at display time by seeking to local_header_offset in the EPUB ZIP and
+// reading ~30 bytes from the local file header (no central-directory
+// walk required).
+
+struct CmbImageRef {
+  uint32_t local_header_offset;  // offset to local file header in original EPUB ZIP
+  uint16_t width;                // EPUB-declared width, or 0 if unknown
+  uint16_t height;               // EPUB-declared height, or 0 if unknown
+};
+static_assert(sizeof(CmbImageRef) == 8, "CmbImageRef must be exactly 8 bytes");
+
+// ---------------------------------------------------------------------------
+// Per-chapter descriptor entry (8 bytes each; NOT loaded into RAM)
+// ---------------------------------------------------------------------------
+
+struct CmbParaDescriptor {
+  uint32_t file_offset;  // absolute file offset of this block record
+  uint32_t char_offset;  // cumulative UTF-8 bytes of text before this block
+};
+static_assert(sizeof(CmbParaDescriptor) == 8, "CmbParaDescriptor must be exactly 8 bytes");
+
+// ---------------------------------------------------------------------------
+// Block-type tags (used inside the per-chapter content blob)
+// ---------------------------------------------------------------------------
+//
+// Each tagged record is { type(u8), payload_length(u16), payload(u8 x len) }.
+// Unknown types MUST be skipped by readers using the length prefix --
+// this is the forward-compatibility hook.
+
+inline constexpr uint8_t kCmbBlockText = 0;        // paragraph of text + styling
+inline constexpr uint8_t kCmbBlockImage = 1;       // image reference (idx into image table)
+inline constexpr uint8_t kCmbBlockHr = 2;          // horizontal rule
+inline constexpr uint8_t kCmbBlockPageBreak = 3;   // hard page break
+// 4..127 reserved for future standard types
+// 128..255 reserved for vendor extensions
+
+// ---------------------------------------------------------------------------
+// Sentinel values for optional fields
+// ---------------------------------------------------------------------------
+
+inline constexpr uint8_t kCmbAlignDefault = 0xFF;
+inline constexpr int16_t kCmbIndentNone = 0x7FFF;
+inline constexpr uint16_t kCmbSpacingDefault = 0xFFFF;
+inline constexpr uint16_t kCmbNoImage = 0xFFFF;
+
+// ---------------------------------------------------------------------------
+// Little-endian serialization helpers
+// ---------------------------------------------------------------------------
+//
+// We never trust the compiler's endianness or struct layout for the
+// on-disk format. Writers go through these helpers byte-by-byte;
+// readers do the same on the way in. Inlined so the cost is identical
+// to a direct cast on a little-endian host.
+
+inline void cmb_write_u8(uint8_t* dst, uint8_t v) { dst[0] = v; }
+
+inline void cmb_write_u16(uint8_t* dst, uint16_t v) {
+  dst[0] = static_cast<uint8_t>(v);
+  dst[1] = static_cast<uint8_t>(v >> 8);
+}
+
+inline void cmb_write_i16(uint8_t* dst, int16_t v) { cmb_write_u16(dst, static_cast<uint16_t>(v)); }
+
+inline void cmb_write_u32(uint8_t* dst, uint32_t v) {
+  dst[0] = static_cast<uint8_t>(v);
+  dst[1] = static_cast<uint8_t>(v >> 8);
+  dst[2] = static_cast<uint8_t>(v >> 16);
+  dst[3] = static_cast<uint8_t>(v >> 24);
+}
+
+inline uint8_t cmb_read_u8(const uint8_t* src) { return src[0]; }
+
+inline uint16_t cmb_read_u16(const uint8_t* src) {
+  return static_cast<uint16_t>(src[0]) | (static_cast<uint16_t>(src[1]) << 8);
+}
+
+inline int16_t cmb_read_i16(const uint8_t* src) { return static_cast<int16_t>(cmb_read_u16(src)); }
+
+inline uint32_t cmb_read_u32(const uint8_t* src) {
+  return static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+         (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24);
+}
+
+// Header pack / unpack -- writes the 32-byte fixed header out as bytes
+// using the LE helpers above. Use these in CmbWriter::finish() and
+// CmbReader::open() instead of memcpy'ing the struct (which would
+// depend on compiler-specific padding).
+
+inline void cmb_write_header(uint8_t out[32], const CmbHeader& h) {
+  std::memcpy(out, h.magic, 4);
+  cmb_write_u16(out + 4, h.version);
+  cmb_write_u16(out + 6, h.flags);
+  cmb_write_u32(out + 8, h.paragraph_count);
+  cmb_write_u16(out + 12, h.chapter_count);
+  cmb_write_u16(out + 14, h.image_count);
+  cmb_write_u32(out + 16, h.anchor_offset);
+  cmb_write_u32(out + 20, h.chapter_offset);
+  cmb_write_u32(out + 24, h.image_offset);
+  cmb_write_u32(out + 28, h.meta_offset);
+}
+
+inline void cmb_read_header(const uint8_t in[32], CmbHeader& h) {
+  std::memcpy(h.magic, in, 4);
+  h.version = cmb_read_u16(in + 4);
+  h.flags = cmb_read_u16(in + 6);
+  h.paragraph_count = cmb_read_u32(in + 8);
+  h.chapter_count = cmb_read_u16(in + 12);
+  h.image_count = cmb_read_u16(in + 14);
+  h.anchor_offset = cmb_read_u32(in + 16);
+  h.chapter_offset = cmb_read_u32(in + 20);
+  h.image_offset = cmb_read_u32(in + 24);
+  h.meta_offset = cmb_read_u32(in + 28);
+}
+
+// Returns true iff the four magic bytes match "CMB1". Use this BEFORE
+// trusting any other header field -- defends against opening a file
+// that happens to start with parseable bytes but isn't a .cmb at all.
+inline bool cmb_magic_matches(const uint8_t magic[4]) {
+  return magic[0] == 'C' && magic[1] == 'M' && magic[2] == 'B' && magic[3] == '1';
+}
+
+}  // namespace cmb

--- a/lib/Cmb/CmbFormat.h
+++ b/lib/Cmb/CmbFormat.h
@@ -47,6 +47,8 @@
 
 #include <cstdint>
 #include <cstring>
+#include <string>
+#include <vector>
 
 namespace cmb {
 
@@ -230,5 +232,43 @@ inline void cmb_read_header(const uint8_t in[32], CmbHeader& h) {
 inline bool cmb_magic_matches(const uint8_t magic[4]) {
   return magic[0] == 'C' && magic[1] == 'M' && magic[2] == 'B' && magic[3] == '1';
 }
+
+// ---------------------------------------------------------------------------
+// In-memory paragraph representation
+// ---------------------------------------------------------------------------
+//
+// Layout-independent: text is UTF-8 with no embedded line breaks (the
+// reader runs layout at chapter-load time). Style information starts
+// minimal -- text, optional inline image ref, paragraph type -- and
+// will grow over follow-up commits (style runs for bold/italic,
+// alignment, heading level, anchor ids for in-book links). Encoded
+// on disk inside a chapter's content blob as a tagged record:
+//
+//   {type:u8, payload_length:u16, payload:bytes[payload_length]}
+//
+// Where the payload layout depends on the type tag. Readers must
+// SKIP unknown type tags using the length prefix -- this is what
+// keeps v1 readers forward-compatible with future block kinds.
+//
+// Payload layouts (subject to extension in subsequent commits):
+//
+//   kCmbBlockText:
+//     text_len:u32
+//     text:bytes[text_len]      -- UTF-8
+//
+//   kCmbBlockImage:
+//     image_key:u16             -- index into image ref table
+//
+//   kCmbBlockHr, kCmbBlockPageBreak:
+//     (empty payload)
+
+struct CmbParagraph {
+  uint8_t type = kCmbBlockText;
+  // For kCmbBlockText: UTF-8 paragraph contents. Empty for non-text.
+  std::string text;
+  // For kCmbBlockImage: index into the file's image-ref table.
+  // kCmbNoImage when not an image block.
+  uint16_t image_key = kCmbNoImage;
+};
 
 }  // namespace cmb

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -91,11 +91,8 @@ bool CmbReader::open(const char* path) {
     }
   }
 
-  // ---- metadata blob (v2) ----
-  //   title_len:u16, title:bytes
-  //   author_len:u16, author:bytes
-  //   spine_count:u16, spine_entries[{href_len:u16, href:bytes}]
-  //   toc_count:u16 (reserved; not consumed yet)
+  // ---- metadata blob (v3) ----
+  // Layout documented in CmbFormat.h's CmbBookMetadata section.
   if (!seek_to(f_, header_.meta_offset)) {
     close();
     return false;
@@ -111,14 +108,15 @@ bool CmbReader::open(const char* path) {
     }
     return true;
   };
-  if (!read_lp_string_u16(metadata_title_) || !read_lp_string_u16(metadata_author_)) {
+
+  if (!read_lp_string_u16(metadata_.title) || !read_lp_string_u16(metadata_.author) ||
+      !read_lp_string_u16(metadata_.language) || !read_lp_string_u16(metadata_.cover_href) ||
+      !read_lp_string_u16(metadata_.text_reference_href)) {
     close();
     return false;
   }
 
-  // Spine table (v2). If chapter_count and spine_count disagree the
-  // writer was buggy -- accept whatever the file says and trust the
-  // reader's later bounds checks to handle out-of-range access.
+  // Spine table: {href, cumulative_size} per entry.
   {
     uint8_t lenbuf[2];
     if (!read_exact(f_, lenbuf, sizeof(lenbuf))) {
@@ -126,19 +124,41 @@ bool CmbReader::open(const char* path) {
       return false;
     }
     const uint16_t spine_count = cmb_read_u16(lenbuf);
-    spine_files_.resize(spine_count);
+    metadata_.spine.resize(spine_count);
     for (uint16_t i = 0; i < spine_count; ++i) {
-      if (!read_lp_string_u16(spine_files_[i])) {
+      if (!read_lp_string_u16(metadata_.spine[i].href)) {
+        close();
+        return false;
+      }
+      uint8_t cum_buf[4];
+      if (!read_exact(f_, cum_buf, sizeof(cum_buf))) {
+        close();
+        return false;
+      }
+      metadata_.spine[i].cumulative_size = cmb_read_u32(cum_buf);
+    }
+  }
+
+  // CSS files list.
+  {
+    uint8_t lenbuf[2];
+    if (!read_exact(f_, lenbuf, sizeof(lenbuf))) {
+      close();
+      return false;
+    }
+    const uint16_t css_count = cmb_read_u16(lenbuf);
+    metadata_.css_files.resize(css_count);
+    for (uint16_t i = 0; i < css_count; ++i) {
+      if (!read_lp_string_u16(metadata_.css_files[i])) {
         close();
         return false;
       }
     }
   }
 
-  // toc_count slot exists in v2 but is always 0 here. v3 of the
-  // format populates entries beyond it; the reader reads + ignores
-  // them when toc_count > 0 (skip-by-length over their fields).
-  // For v2 specifically: don't bother reading it, we don't use it.
+  // toc_count slot exists in v3 but is always 0 (v4 populates).
+  // Not consumed here -- if a caller cares it's at the current file
+  // position; for now we just leave the cursor sitting on it.
   return true;
 }
 
@@ -150,9 +170,7 @@ void CmbReader::close() {
   header_ = CmbHeader{};
   chapters_.clear();
   images_.clear();
-  metadata_title_.clear();
-  metadata_author_.clear();
-  spine_files_.clear();
+  metadata_ = CmbBookMetadata{};
 }
 
 uint16_t CmbReader::chapter_paragraph_count(uint16_t chapter_idx) const {

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -1,0 +1,215 @@
+#include "CmbReader.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace cmb {
+
+namespace {
+
+// Small wrapper around fread that treats partial reads as failures --
+// every read in the .cmb format is fixed-size and known, so a short
+// read indicates either EOF or a corrupted file. Either way the
+// caller should bail.
+inline bool read_exact(FILE* f, void* buf, size_t size) {
+  return std::fread(buf, 1, size, f) == size;
+}
+
+inline bool seek_to(FILE* f, uint32_t offset) {
+  return std::fseek(f, static_cast<long>(offset), SEEK_SET) == 0;
+}
+
+}  // namespace
+
+bool CmbReader::open(const char* path) {
+  if (f_ != nullptr) close();
+  f_ = std::fopen(path, "rb");
+  if (f_ == nullptr) return false;
+
+  // ---- header ----
+  uint8_t header_bytes[32];
+  if (!read_exact(f_, header_bytes, sizeof(header_bytes))) {
+    close();
+    return false;
+  }
+  if (!cmb_magic_matches(header_bytes)) {
+    close();
+    return false;
+  }
+  cmb_read_header(header_bytes, header_);
+
+  // For forward-compat with v2+: a future reader that wants to parse
+  // a v1 file is fine. The other direction -- v1 reader seeing a
+  // higher version -- is rejected for now since the v1->v2 changes
+  // may add fields the v1 reader can't interpret correctly. When the
+  // companion task lands and we bump to v2, this check loosens to
+  // "version <= kCmbVersion".
+  if (header_.version != kCmbVersion) {
+    close();
+    return false;
+  }
+
+  // ---- chapter table ----
+  if (header_.chapter_count > 0) {
+    if (!seek_to(f_, header_.chapter_offset)) {
+      close();
+      return false;
+    }
+    chapters_.resize(header_.chapter_count);
+    for (size_t i = 0; i < chapters_.size(); ++i) {
+      uint8_t buf[16];
+      if (!read_exact(f_, buf, sizeof(buf))) {
+        close();
+        return false;
+      }
+      CmbChapterEntry& c = chapters_[i];
+      c.para_table_offset = cmb_read_u32(buf);
+      c.reserved0 = cmb_read_u32(buf + 4);
+      c.paragraph_count = cmb_read_u16(buf + 8);
+      c.reserved1 = cmb_read_u16(buf + 10);
+      c.char_count = cmb_read_u32(buf + 12);
+    }
+  }
+
+  // ---- image ref table ----
+  if (header_.image_count > 0) {
+    if (!seek_to(f_, header_.image_offset)) {
+      close();
+      return false;
+    }
+    images_.resize(header_.image_count);
+    for (size_t i = 0; i < images_.size(); ++i) {
+      uint8_t buf[8];
+      if (!read_exact(f_, buf, sizeof(buf))) {
+        close();
+        return false;
+      }
+      CmbImageRef& r = images_[i];
+      r.local_header_offset = cmb_read_u32(buf);
+      r.width = cmb_read_u16(buf + 4);
+      r.height = cmb_read_u16(buf + 6);
+    }
+  }
+
+  // ---- metadata blob ----
+  // Title + author only for v1. TOC entries are reserved at the end
+  // of the blob but unused by the reader at this checkpoint.
+  if (!seek_to(f_, header_.meta_offset)) {
+    close();
+    return false;
+  }
+  auto read_lp_string = [this](std::string& out) {
+    uint8_t lenbuf[2];
+    if (!read_exact(f_, lenbuf, sizeof(lenbuf))) return false;
+    const uint16_t len = cmb_read_u16(lenbuf);
+    out.resize(len);
+    if (len > 0 && !read_exact(f_, out.data(), len)) {
+      out.clear();
+      return false;
+    }
+    return true;
+  };
+  if (!read_lp_string(metadata_title_) || !read_lp_string(metadata_author_)) {
+    close();
+    return false;
+  }
+
+  return true;
+}
+
+void CmbReader::close() {
+  if (f_ != nullptr) {
+    std::fclose(f_);
+    f_ = nullptr;
+  }
+  header_ = CmbHeader{};
+  chapters_.clear();
+  images_.clear();
+  metadata_title_.clear();
+  metadata_author_.clear();
+}
+
+uint16_t CmbReader::chapter_paragraph_count(uint16_t chapter_idx) const {
+  if (chapter_idx >= chapters_.size()) return 0;
+  return chapters_[chapter_idx].paragraph_count;
+}
+
+uint32_t CmbReader::chapter_char_count(uint16_t chapter_idx) const {
+  if (chapter_idx >= chapters_.size()) return 0;
+  return chapters_[chapter_idx].char_count;
+}
+
+bool CmbReader::image_ref(uint16_t image_idx, CmbImageRef& out) const {
+  if (image_idx >= images_.size()) return false;
+  out = images_[image_idx];
+  return true;
+}
+
+bool CmbReader::load_paragraph(uint16_t chapter_idx, uint16_t para_idx, CmbParagraph& out) {
+  if (f_ == nullptr) return false;
+  if (chapter_idx >= chapters_.size()) return false;
+  const CmbChapterEntry& c = chapters_[chapter_idx];
+  if (para_idx >= c.paragraph_count) return false;
+
+  // ---- read the per-chapter descriptor for this paragraph (8 bytes
+  // on SD; NOT cached in RAM) ----
+  const uint32_t desc_offset = c.para_table_offset + static_cast<uint32_t>(para_idx) * sizeof(CmbParaDescriptor);
+  if (!seek_to(f_, desc_offset)) return false;
+  uint8_t desc_buf[8];
+  if (!read_exact(f_, desc_buf, sizeof(desc_buf))) return false;
+  const uint32_t file_offset = cmb_read_u32(desc_buf);
+  // char_offset is in desc_buf+4 but unused for paragraph fetch;
+  // exposed as a separate query if/when callers need it.
+
+  return read_paragraph_at(file_offset, out);
+}
+
+bool CmbReader::read_paragraph_at(uint32_t file_offset, CmbParagraph& out) {
+  if (!seek_to(f_, file_offset)) return false;
+
+  uint8_t envelope[3];
+  if (!read_exact(f_, envelope, sizeof(envelope))) return false;
+  out.type = envelope[0];
+  const uint16_t payload_len = cmb_read_u16(envelope + 1);
+
+  // Default-init payload fields so unknown / empty types come back
+  // in a defined state.
+  out.text.clear();
+  out.image_key = kCmbNoImage;
+
+  switch (out.type) {
+    case kCmbBlockText: {
+      if (payload_len < 4) return false;
+      uint8_t hdr[4];
+      if (!read_exact(f_, hdr, sizeof(hdr))) return false;
+      const uint32_t text_len = cmb_read_u32(hdr);
+      if (text_len + 4 > payload_len) return false;
+      out.text.resize(text_len);
+      if (text_len > 0 && !read_exact(f_, out.text.data(), text_len)) {
+        out.text.clear();
+        return false;
+      }
+      break;
+    }
+    case kCmbBlockImage: {
+      if (payload_len < 2) return false;
+      uint8_t hdr[2];
+      if (!read_exact(f_, hdr, sizeof(hdr))) return false;
+      out.image_key = cmb_read_u16(hdr);
+      break;
+    }
+    case kCmbBlockHr:
+    case kCmbBlockPageBreak:
+      // No payload; envelope was enough.
+      break;
+    default:
+      // Unknown tag -- v1 reader is allowed to either bail or skip.
+      // For now we report success with type set to the unknown tag
+      // value so the caller can decide. The length prefix would let
+      // us advance past it if needed.
+      break;
+  }
+  return true;
+}
+
+}  // namespace cmb

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -156,9 +156,30 @@ bool CmbReader::open(const char* path) {
     }
   }
 
-  // toc_count slot exists in v3 but is always 0 (v4 populates).
-  // Not consumed here -- if a caller cares it's at the current file
-  // position; for now we just leave the cursor sitting on it.
+  // TOC entries (v4).
+  {
+    uint8_t lenbuf[2];
+    if (!read_exact(f_, lenbuf, sizeof(lenbuf))) {
+      close();
+      return false;
+    }
+    const uint16_t toc_count = cmb_read_u16(lenbuf);
+    metadata_.toc.resize(toc_count);
+    for (uint16_t i = 0; i < toc_count; ++i) {
+      CmbTocEntry& e = metadata_.toc[i];
+      if (!read_lp_string_u16(e.title) || !read_lp_string_u16(e.href) || !read_lp_string_u16(e.anchor)) {
+        close();
+        return false;
+      }
+      uint8_t lvl = 0;
+      if (!read_exact(f_, &lvl, 1)) {
+        close();
+        return false;
+      }
+      e.level = lvl;
+    }
+  }
+
   return true;
 }
 

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -175,27 +175,69 @@ bool CmbReader::read_paragraph_at(uint32_t file_offset, CmbParagraph& out) {
   // Default-init payload fields so unknown / empty types come back
   // in a defined state.
   out.text.clear();
+  out.runs.clear();
+  out.alignment = kCmbAlignDefault;
+  out.heading_level = 0;
   out.image_key = kCmbNoImage;
+  out.anchor_id.clear();
 
   switch (out.type) {
     case kCmbBlockText: {
-      if (payload_len < 4) return false;
-      uint8_t hdr[4];
-      if (!read_exact(f_, hdr, sizeof(hdr))) return false;
-      const uint32_t text_len = cmb_read_u32(hdr);
-      if (text_len + 4 > payload_len) return false;
+      // Min text payload: alignment(1) + heading(1) + text_len(4) +
+      // run_count(2) + anchor_len(1) = 9 bytes.
+      if (payload_len < 9) return false;
+      uint8_t head[6];
+      if (!read_exact(f_, head, sizeof(head))) return false;
+      out.alignment = head[0];
+      out.heading_level = head[1];
+      const uint32_t text_len = cmb_read_u32(head + 2);
+      // Bounds-check against the envelope length to avoid trusting a
+      // corrupt text_len that would read past the record.
+      if (static_cast<uint64_t>(text_len) + 6 + 2 + 1 > payload_len) return false;
       out.text.resize(text_len);
       if (text_len > 0 && !read_exact(f_, out.text.data(), text_len)) {
         out.text.clear();
         return false;
       }
+
+      uint8_t run_count_buf[2];
+      if (!read_exact(f_, run_count_buf, sizeof(run_count_buf))) return false;
+      const uint16_t run_count = cmb_read_u16(run_count_buf);
+      out.runs.reserve(run_count);
+      for (uint16_t i = 0; i < run_count; ++i) {
+        uint8_t run_buf[5];
+        if (!read_exact(f_, run_buf, sizeof(run_buf))) return false;
+        CmbStyleRun r;
+        r.start = cmb_read_u16(run_buf);
+        r.length = cmb_read_u16(run_buf + 2);
+        r.style = run_buf[4];
+        out.runs.push_back(r);
+      }
+
+      uint8_t anchor_len = 0;
+      if (!read_exact(f_, &anchor_len, 1)) return false;
+      if (anchor_len > 0) {
+        out.anchor_id.resize(anchor_len);
+        if (!read_exact(f_, out.anchor_id.data(), anchor_len)) {
+          out.anchor_id.clear();
+          return false;
+        }
+      }
       break;
     }
     case kCmbBlockImage: {
-      if (payload_len < 2) return false;
-      uint8_t hdr[2];
-      if (!read_exact(f_, hdr, sizeof(hdr))) return false;
-      out.image_key = cmb_read_u16(hdr);
+      if (payload_len < 3) return false;
+      uint8_t head[3];
+      if (!read_exact(f_, head, sizeof(head))) return false;
+      out.image_key = cmb_read_u16(head);
+      const uint8_t anchor_len = head[2];
+      if (anchor_len > 0) {
+        out.anchor_id.resize(anchor_len);
+        if (!read_exact(f_, out.anchor_id.data(), anchor_len)) {
+          out.anchor_id.clear();
+          return false;
+        }
+      }
       break;
     }
     case kCmbBlockHr:

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -91,14 +91,16 @@ bool CmbReader::open(const char* path) {
     }
   }
 
-  // ---- metadata blob ----
-  // Title + author only for v1. TOC entries are reserved at the end
-  // of the blob but unused by the reader at this checkpoint.
+  // ---- metadata blob (v2) ----
+  //   title_len:u16, title:bytes
+  //   author_len:u16, author:bytes
+  //   spine_count:u16, spine_entries[{href_len:u16, href:bytes}]
+  //   toc_count:u16 (reserved; not consumed yet)
   if (!seek_to(f_, header_.meta_offset)) {
     close();
     return false;
   }
-  auto read_lp_string = [this](std::string& out) {
+  auto read_lp_string_u16 = [this](std::string& out) {
     uint8_t lenbuf[2];
     if (!read_exact(f_, lenbuf, sizeof(lenbuf))) return false;
     const uint16_t len = cmb_read_u16(lenbuf);
@@ -109,11 +111,34 @@ bool CmbReader::open(const char* path) {
     }
     return true;
   };
-  if (!read_lp_string(metadata_title_) || !read_lp_string(metadata_author_)) {
+  if (!read_lp_string_u16(metadata_title_) || !read_lp_string_u16(metadata_author_)) {
     close();
     return false;
   }
 
+  // Spine table (v2). If chapter_count and spine_count disagree the
+  // writer was buggy -- accept whatever the file says and trust the
+  // reader's later bounds checks to handle out-of-range access.
+  {
+    uint8_t lenbuf[2];
+    if (!read_exact(f_, lenbuf, sizeof(lenbuf))) {
+      close();
+      return false;
+    }
+    const uint16_t spine_count = cmb_read_u16(lenbuf);
+    spine_files_.resize(spine_count);
+    for (uint16_t i = 0; i < spine_count; ++i) {
+      if (!read_lp_string_u16(spine_files_[i])) {
+        close();
+        return false;
+      }
+    }
+  }
+
+  // toc_count slot exists in v2 but is always 0 here. v3 of the
+  // format populates entries beyond it; the reader reads + ignores
+  // them when toc_count > 0 (skip-by-length over their fields).
+  // For v2 specifically: don't bother reading it, we don't use it.
   return true;
 }
 
@@ -127,6 +152,7 @@ void CmbReader::close() {
   images_.clear();
   metadata_title_.clear();
   metadata_author_.clear();
+  spine_files_.clear();
 }
 
 uint16_t CmbReader::chapter_paragraph_count(uint16_t chapter_idx) const {

--- a/lib/Cmb/CmbReader.cpp
+++ b/lib/Cmb/CmbReader.cpp
@@ -1,30 +1,49 @@
 #include "CmbReader.h"
 
-#include <cstdio>
 #include <cstring>
 
 namespace cmb {
 
 namespace {
 
-// Small wrapper around fread that treats partial reads as failures --
-// every read in the .cmb format is fixed-size and known, so a short
-// read indicates either EOF or a corrupted file. Either way the
-// caller should bail.
+// File backend split mirrors CmbWriter: HalFile on device (the SD card
+// isn't reachable through libc stdio), plain FILE* on host (round-trip
+// tests + any future desktop converter).
+
+#ifdef ARDUINO
+inline bool read_exact(FsFile& f, void* buf, size_t size) {
+  // FsFile::read returns int (-1 on error, less than size on partial).
+  const int n = f.read(buf, size);
+  return n >= 0 && static_cast<size_t>(n) == size;
+}
+inline bool seek_to(FsFile& f, uint32_t offset) { return f.seek(offset); }
+#else
 inline bool read_exact(FILE* f, void* buf, size_t size) {
   return std::fread(buf, 1, size, f) == size;
 }
-
 inline bool seek_to(FILE* f, uint32_t offset) {
   return std::fseek(f, static_cast<long>(offset), SEEK_SET) == 0;
 }
+#endif
 
 }  // namespace
 
+bool CmbReader::is_open() const {
+#ifdef ARDUINO
+  return static_cast<bool>(f_);
+#else
+  return f_ != nullptr;
+#endif
+}
+
 bool CmbReader::open(const char* path) {
-  if (f_ != nullptr) close();
+  if (is_open()) close();
+#ifdef ARDUINO
+  if (!HalStorage::getInstance().openFileForRead("CMB", path, f_)) return false;
+#else
   f_ = std::fopen(path, "rb");
   if (f_ == nullptr) return false;
+#endif
 
   // ---- header ----
   uint8_t header_bytes[32];
@@ -184,9 +203,13 @@ bool CmbReader::open(const char* path) {
 }
 
 void CmbReader::close() {
-  if (f_ != nullptr) {
+  if (is_open()) {
+#ifdef ARDUINO
+    f_.close();
+#else
     std::fclose(f_);
     f_ = nullptr;
+#endif
   }
   header_ = CmbHeader{};
   chapters_.clear();
@@ -211,7 +234,7 @@ bool CmbReader::image_ref(uint16_t image_idx, CmbImageRef& out) const {
 }
 
 bool CmbReader::load_paragraph(uint16_t chapter_idx, uint16_t para_idx, CmbParagraph& out) {
-  if (f_ == nullptr) return false;
+  if (!is_open()) return false;
   if (chapter_idx >= chapters_.size()) return false;
   const CmbChapterEntry& c = chapters_[chapter_idx];
   if (para_idx >= c.paragraph_count) return false;

--- a/lib/Cmb/CmbReader.h
+++ b/lib/Cmb/CmbReader.h
@@ -31,9 +31,17 @@
 // ~8 KB peak; per-paragraph descriptors are seeked on demand.
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 #include <vector>
+
+#ifdef ARDUINO
+// On-device: file I/O goes through the SdFat-backed HalStorage layer.
+// stdio fopen/fread don't see the SD card (no VFS registration), so
+// the reader has to use HalFile here -- mirroring CmbWriter.
+#include <HalStorage.h>
+#else
+#include <cstdio>
+#endif
 
 #include "CmbFormat.h"
 
@@ -48,7 +56,7 @@ class CmbReader {
 
   bool open(const char* path);
   void close();
-  bool is_open() const { return f_ != nullptr; }
+  bool is_open() const;
 
   // Header fields. Valid after a successful open().
   uint32_t paragraph_count() const { return header_.paragraph_count; }
@@ -94,7 +102,11 @@ class CmbReader {
   }
 
  private:
+#ifdef ARDUINO
+  FsFile f_;
+#else
   FILE* f_ = nullptr;
+#endif
   CmbHeader header_{};
 
   // In-RAM tables. Sized at open() and never resized after.

--- a/lib/Cmb/CmbReader.h
+++ b/lib/Cmb/CmbReader.h
@@ -75,6 +75,10 @@ class CmbReader {
   // Metadata loaded at open(). Empty if the file didn't include them.
   const std::string& metadata_title() const { return metadata_title_; }
   const std::string& metadata_author() const { return metadata_author_; }
+  // Spine entry hrefs in spine order (same indexing as chapter_count).
+  // Used by Epub::load to populate BookMetadataCache without parsing
+  // the EPUB's content.opf. Empty when the .cmb predates v2.
+  const std::vector<std::string>& spine_files() const { return spine_files_; }
 
  private:
   FILE* f_ = nullptr;
@@ -85,6 +89,7 @@ class CmbReader {
   std::vector<CmbImageRef> images_;
   std::string metadata_title_;
   std::string metadata_author_;
+  std::vector<std::string> spine_files_;
 
   // Helper: seek + read one paragraph record at a known absolute
   // file offset. Used by load_paragraph after the descriptor lookup.

--- a/lib/Cmb/CmbReader.h
+++ b/lib/Cmb/CmbReader.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// CmbReader -- read-side of the CrumBLE .cmb compact-binary book
+// format. Loads the small fixed-size tables (header, chapter table,
+// image refs, metadata) into RAM at open(); the per-chapter paragraph
+// descriptor tables stay on SD and are seeked on demand. This is the
+// trick that keeps a 377-spine-item book's open() at ~5 KB heap
+// instead of ~136 KB.
+//
+// Usage:
+//
+//   cmb::CmbReader r;
+//   if (!r.open("book.cmb")) { ... }
+//
+//   r.chapter_count();
+//   r.image_count();
+//   r.metadata_title();
+//   r.metadata_author();
+//
+//   for (uint16_t ci = 0; ci < r.chapter_count(); ++ci) {
+//     const auto N = r.chapter_paragraph_count(ci);
+//     for (uint16_t pi = 0; pi < N; ++pi) {
+//       cmb::CmbParagraph p;
+//       if (r.load_paragraph(ci, pi, p)) { ... }
+//     }
+//   }
+//
+// Heap budget at open: header (32 B) + chapter table (16 B per
+// chapter) + image refs (8 B per image) + metadata strings. For a
+// 377-chapter, 50-image book that's 32 + 6 KB + 400 B + ~2 KB =
+// ~8 KB peak; per-paragraph descriptors are seeked on demand.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "CmbFormat.h"
+
+namespace cmb {
+
+class CmbReader {
+ public:
+  CmbReader() = default;
+  ~CmbReader() { close(); }
+  CmbReader(const CmbReader&) = delete;
+  CmbReader& operator=(const CmbReader&) = delete;
+
+  bool open(const char* path);
+  void close();
+  bool is_open() const { return f_ != nullptr; }
+
+  // Header fields. Valid after a successful open().
+  uint32_t paragraph_count() const { return header_.paragraph_count; }
+  uint16_t chapter_count() const { return header_.chapter_count; }
+  uint16_t image_count() const { return header_.image_count; }
+
+  // Per-chapter accessors. chapter_idx must be < chapter_count();
+  // returns 0 if out of range.
+  uint16_t chapter_paragraph_count(uint16_t chapter_idx) const;
+  uint32_t chapter_char_count(uint16_t chapter_idx) const;
+
+  // Load the Nth paragraph of a chapter. Seeks to the descriptor
+  // table on SD to find the file offset, then seeks to that offset
+  // to read the tagged record. Returns true on success; on false,
+  // `out` is left in an unspecified state and the read should be
+  // treated as missing.
+  bool load_paragraph(uint16_t chapter_idx, uint16_t para_idx, CmbParagraph& out);
+
+  // Direct image-ref access. Indices match the image_key stored on
+  // CmbParagraph (for kCmbBlockImage). out_width / out_height are
+  // the EPUB-declared values; 0 means "resolve at display time".
+  bool image_ref(uint16_t image_idx, CmbImageRef& out) const;
+
+  // Metadata loaded at open(). Empty if the file didn't include them.
+  const std::string& metadata_title() const { return metadata_title_; }
+  const std::string& metadata_author() const { return metadata_author_; }
+
+ private:
+  FILE* f_ = nullptr;
+  CmbHeader header_{};
+
+  // In-RAM tables. Sized at open() and never resized after.
+  std::vector<CmbChapterEntry> chapters_;
+  std::vector<CmbImageRef> images_;
+  std::string metadata_title_;
+  std::string metadata_author_;
+
+  // Helper: seek + read one paragraph record at a known absolute
+  // file offset. Used by load_paragraph after the descriptor lookup.
+  bool read_paragraph_at(uint32_t file_offset, CmbParagraph& out);
+};
+
+}  // namespace cmb

--- a/lib/Cmb/CmbReader.h
+++ b/lib/Cmb/CmbReader.h
@@ -72,13 +72,26 @@ class CmbReader {
   // the EPUB-declared values; 0 means "resolve at display time".
   bool image_ref(uint16_t image_idx, CmbImageRef& out) const;
 
-  // Metadata loaded at open(). Empty if the file didn't include them.
-  const std::string& metadata_title() const { return metadata_title_; }
-  const std::string& metadata_author() const { return metadata_author_; }
-  // Spine entry hrefs in spine order (same indexing as chapter_count).
-  // Used by Epub::load to populate BookMetadataCache without parsing
-  // the EPUB's content.opf. Empty when the .cmb predates v2.
-  const std::vector<std::string>& spine_files() const { return spine_files_; }
+  // Aggregate metadata loaded at open(). Title/author/language/cover/
+  // text-ref strings + spine entries (with cumulative sizes) + CSS
+  // file paths -- everything Epub::load needs to populate
+  // BookMetadataCache without parsing the EPUB.
+  const CmbBookMetadata& metadata() const { return metadata_; }
+
+  // Convenience shorthands kept for the round-trip tests and for the
+  // converter / stats-style callers that only need a single field.
+  const std::string& metadata_title() const { return metadata_.title; }
+  const std::string& metadata_author() const { return metadata_.author; }
+  // Spine entry hrefs in spine order; legacy accessor that returns a
+  // freshly-built vector of just the hrefs for callers that don't
+  // need the cumulative_size data. Prefer metadata().spine for new
+  // code.
+  std::vector<std::string> spine_files() const {
+    std::vector<std::string> out;
+    out.reserve(metadata_.spine.size());
+    for (const auto& e : metadata_.spine) out.push_back(e.href);
+    return out;
+  }
 
  private:
   FILE* f_ = nullptr;
@@ -87,9 +100,7 @@ class CmbReader {
   // In-RAM tables. Sized at open() and never resized after.
   std::vector<CmbChapterEntry> chapters_;
   std::vector<CmbImageRef> images_;
-  std::string metadata_title_;
-  std::string metadata_author_;
-  std::vector<std::string> spine_files_;
+  CmbBookMetadata metadata_;
 
   // Helper: seek + read one paragraph record at a known absolute
   // file offset. Used by load_paragraph after the descriptor lookup.

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -285,9 +285,17 @@ uint16_t CmbWriter::add_image_ref(uint32_t local_header_offset, uint16_t width, 
   return static_cast<uint16_t>(images_.size() - 1);
 }
 
-bool CmbWriter::finish(const std::string& metadata_title, const std::string& metadata_author) {
+bool CmbWriter::finish(const std::string& metadata_title, const std::string& metadata_author,
+                       const std::vector<std::string>& spine_files) {
   if (!bw_.is_open()) return false;
   if (in_chapter_) return false;  // caller forgot end_chapter()
+  // Spine count is u16 in the metadata blob.
+  if (spine_files.size() > 0xFFFF) return false;
+  // The spine table is keyed by chapter index; the two MUST match in
+  // length so Epub::load can populate BookMetadataCache one entry
+  // per chapter. The caller is responsible (typically the EPUB->.cmb
+  // converter passes book.getSpineItem(i).href in order).
+  if (!spine_files.empty() && spine_files.size() != chapters_.size()) return false;
 
   // ---- chapter table ----
   const uint32_t chapter_offset = bw_.tell();
@@ -319,22 +327,42 @@ bool CmbWriter::finish(const std::string& metadata_title, const std::string& met
   cmb_write_u32(anchor_count_buf, 0);
   if (!bw_.write(anchor_count_buf, sizeof(anchor_count_buf))) return false;
 
-  // ---- metadata + TOC blob ----
-  // Minimal v1 layout:
+  // ---- metadata + TOC blob (v2 layout) ----
   //   title_len:u16, title:bytes
   //   author_len:u16, author:bytes
-  //   toc_entry_count:u16, toc_entries...  (toc reserved for follow-up)
+  //   spine_count:u16
+  //   spine_entries[spine_count]: { href_len:u16, href:bytes }
+  //   toc_count:u16, toc_entries... (TOC entries stub for v2; populated
+  //                                  in a later format bump)
+  //
+  // v1 stored only title + author + (mislabelled) toc_count. v2 inserts
+  // the spine table between author and toc_count -- v1 readers fail the
+  // version check and bail before reaching this blob.
   const uint32_t meta_offset = bw_.tell();
   {
     uint8_t lenbuf[2];
+
+    // title
     cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_title.size()));
     if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
     if (!metadata_title.empty() && !bw_.write(metadata_title.data(), metadata_title.size())) return false;
 
+    // author
     cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_author.size()));
     if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
     if (!metadata_author.empty() && !bw_.write(metadata_author.data(), metadata_author.size())) return false;
 
+    // spine_count + spine_entries
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(spine_files.size()));
+    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+    for (const std::string& href : spine_files) {
+      if (href.size() > 0xFFFF) return false;  // href_len is u16
+      cmb_write_u16(lenbuf, static_cast<uint16_t>(href.size()));
+      if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+      if (!href.empty() && !bw_.write(href.data(), href.size())) return false;
+    }
+
+    // toc_count (stub)
     uint8_t toc_count[2];
     cmb_write_u16(toc_count, 0);
     if (!bw_.write(toc_count, sizeof(toc_count))) return false;

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -1,0 +1,327 @@
+#include "CmbWriter.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+namespace cmb {
+
+// ===========================================================================
+// BufferedFileWriter
+// ===========================================================================
+
+bool BufferedFileWriter::open(const char* path) {
+  if (f_ != nullptr) close();
+  f_ = std::fopen(path, "wb+");
+  if (f_ == nullptr) return false;
+  pos_ = 0;
+  used_ = 0;
+  return true;
+}
+
+void BufferedFileWriter::close() {
+  if (f_ == nullptr) return;
+  // Best-effort flush; if it fails we still want to close the handle.
+  (void)flush();
+  std::fclose(f_);
+  f_ = nullptr;
+  pos_ = 0;
+  used_ = 0;
+}
+
+bool BufferedFileWriter::flush() {
+  if (f_ == nullptr) return false;
+  if (used_ == 0) return true;
+  const size_t written = std::fwrite(buf_, 1, used_, f_);
+  used_ = 0;
+  return written != 0;
+}
+
+bool BufferedFileWriter::write(const void* data, size_t size) {
+  if (f_ == nullptr) return false;
+  const uint8_t* src = static_cast<const uint8_t*>(data);
+
+  while (size > 0) {
+    // Fast path: whole big writes that don't fit in the buffer can bypass
+    // the buffer entirely once it's been flushed -- saves a copy.
+    if (used_ == 0 && size >= kBufSize) {
+      const size_t written = std::fwrite(src, 1, size, f_);
+      if (written != size) return false;
+      pos_ += static_cast<uint32_t>(size);
+      return true;
+    }
+
+    const size_t room = kBufSize - used_;
+    const size_t copy = (size < room) ? size : room;
+    std::memcpy(buf_ + used_, src, copy);
+    used_ += copy;
+    src += copy;
+    size -= copy;
+    pos_ += static_cast<uint32_t>(copy);
+
+    if (used_ == kBufSize) {
+      if (!flush()) return false;
+    }
+  }
+  return true;
+}
+
+bool BufferedFileWriter::seek(uint32_t offset) {
+  if (f_ == nullptr) return false;
+  if (!flush()) return false;
+  if (std::fseek(f_, static_cast<long>(offset), SEEK_SET) != 0) return false;
+  pos_ = offset;
+  return true;
+}
+
+// ===========================================================================
+// CmbWriter
+// ===========================================================================
+
+bool CmbWriter::open(const char* path) {
+  if (!bw_.open(path)) return false;
+
+  // Reserve 32 bytes for the header. We don't know paragraph_count /
+  // chapter_count / offsets yet, so write zeros and patch in finish().
+  // pos_ advances to 32 so subsequent chapter content writes land at
+  // offset 32+.
+  uint8_t zero_header[32] = {};
+  if (!bw_.write(zero_header, sizeof(zero_header))) {
+    bw_.close();
+    return false;
+  }
+
+  paragraph_count_ = 0;
+  chapters_.clear();
+  images_.clear();
+  current_chapter_descriptors_.clear();
+  current_chapter_char_count_ = 0;
+  in_chapter_ = false;
+  return true;
+}
+
+void CmbWriter::close() { bw_.close(); }
+
+void CmbWriter::begin_chapter() {
+  current_chapter_descriptors_.clear();
+  current_chapter_char_count_ = 0;
+  in_chapter_ = true;
+}
+
+size_t CmbWriter::serialize_paragraph(const CmbParagraph& p) {
+  // Compute payload length first so the {tag, length, payload}
+  // envelope is correct -- and so readers can SKIP unknown tags by
+  // jumping length bytes forward without parsing the payload.
+  uint32_t payload_len = 0;
+  switch (p.type) {
+    case kCmbBlockText:
+      payload_len = 4 + static_cast<uint32_t>(p.text.size());
+      break;
+    case kCmbBlockImage:
+      payload_len = 2;
+      break;
+    case kCmbBlockHr:
+    case kCmbBlockPageBreak:
+      payload_len = 0;
+      break;
+    default:
+      // Unknown type tag -- writer refuses to emit ambiguous records.
+      // Phase A.1 only knows the four standard tags. Higher-level
+      // converters should map their own block kinds onto these or
+      // negotiate a vendor-extension tag (>= 128) with the format.
+      return 0;
+  }
+
+  if (payload_len > 0xFFFF) {
+    // length field is u16; any single paragraph exceeding 65 KB of
+    // payload is a writer bug or a pathological book. Bail rather
+    // than silently truncating.
+    return 0;
+  }
+
+  uint8_t envelope[3];
+  envelope[0] = p.type;
+  cmb_write_u16(envelope + 1, static_cast<uint16_t>(payload_len));
+  if (!bw_.write(envelope, sizeof(envelope))) return 0;
+
+  switch (p.type) {
+    case kCmbBlockText: {
+      uint8_t hdr[4];
+      cmb_write_u32(hdr, static_cast<uint32_t>(p.text.size()));
+      if (!bw_.write(hdr, sizeof(hdr))) return 0;
+      if (!p.text.empty()) {
+        if (!bw_.write(p.text.data(), p.text.size())) return 0;
+      }
+      break;
+    }
+    case kCmbBlockImage: {
+      uint8_t hdr[2];
+      cmb_write_u16(hdr, p.image_key);
+      if (!bw_.write(hdr, sizeof(hdr))) return 0;
+      break;
+    }
+    case kCmbBlockHr:
+    case kCmbBlockPageBreak:
+      // No payload bytes.
+      break;
+  }
+  return 3 + payload_len;
+}
+
+bool CmbWriter::write_paragraph(const CmbParagraph& p) {
+  if (!in_chapter_) return false;
+  if (!bw_.is_open()) return false;
+
+  const uint32_t file_offset = bw_.tell();
+  const uint32_t char_offset_before = current_chapter_char_count_;
+
+  const size_t written = serialize_paragraph(p);
+  if (written == 0) return false;
+
+  // Descriptor records this paragraph's location + cumulative char
+  // count. The cumulative count is BEFORE this paragraph so the reader
+  // can ask "give me the paragraph at byte N of the chapter" in O(log
+  // descriptors) without reading payload bytes.
+  CmbParaDescriptor desc;
+  desc.file_offset = file_offset;
+  desc.char_offset = char_offset_before;
+  current_chapter_descriptors_.push_back(desc);
+
+  // Char count tally: only text contributes (image / hr / page break
+  // have zero text content).
+  if (p.type == kCmbBlockText) {
+    current_chapter_char_count_ += static_cast<uint32_t>(p.text.size());
+  }
+  paragraph_count_++;
+  return true;
+}
+
+void CmbWriter::end_chapter() {
+  if (!in_chapter_) return;
+
+  // Per-chapter descriptor table goes RIGHT AFTER the chapter's last
+  // paragraph -- no backward seeks. Record the offset so the chapter
+  // table entry can point at it.
+  const uint32_t para_table_offset = bw_.tell();
+  for (const auto& d : current_chapter_descriptors_) {
+    uint8_t buf[8];
+    cmb_write_u32(buf, d.file_offset);
+    cmb_write_u32(buf + 4, d.char_offset);
+    // Best-effort: a write failure here will surface from the next
+    // bw_ operation; we don't propagate it through end_chapter()'s
+    // void signature to keep the call site shape simple. finish()
+    // also validates by re-checking bw_.is_open().
+    (void)bw_.write(buf, sizeof(buf));
+  }
+
+  CmbChapterEntry entry{};
+  entry.para_table_offset = para_table_offset;
+  entry.reserved0 = 0;
+  entry.paragraph_count = static_cast<uint16_t>(current_chapter_descriptors_.size());
+  entry.reserved1 = 0;
+  entry.char_count = current_chapter_char_count_;
+  chapters_.push_back(entry);
+
+  current_chapter_descriptors_.clear();
+  current_chapter_char_count_ = 0;
+  in_chapter_ = false;
+}
+
+uint16_t CmbWriter::add_image_ref(uint32_t local_header_offset, uint16_t width, uint16_t height) {
+  // Idempotent on the (offset, w, h) tuple. Re-adding the same image
+  // returns the same index -- prevents duplicate entries when the
+  // same image is referenced from multiple paragraphs.
+  for (size_t i = 0; i < images_.size(); ++i) {
+    const CmbImageRef& r = images_[i];
+    if (r.local_header_offset == local_header_offset && r.width == width && r.height == height) {
+      return static_cast<uint16_t>(i);
+    }
+  }
+  CmbImageRef r;
+  r.local_header_offset = local_header_offset;
+  r.width = width;
+  r.height = height;
+  images_.push_back(r);
+  return static_cast<uint16_t>(images_.size() - 1);
+}
+
+bool CmbWriter::finish(const std::string& metadata_title, const std::string& metadata_author) {
+  if (!bw_.is_open()) return false;
+  if (in_chapter_) return false;  // caller forgot end_chapter()
+
+  // ---- chapter table ----
+  const uint32_t chapter_offset = bw_.tell();
+  for (const auto& c : chapters_) {
+    uint8_t buf[16];
+    cmb_write_u32(buf, c.para_table_offset);
+    cmb_write_u32(buf + 4, c.reserved0);
+    cmb_write_u16(buf + 8, c.paragraph_count);
+    cmb_write_u16(buf + 10, c.reserved1);
+    cmb_write_u32(buf + 12, c.char_count);
+    if (!bw_.write(buf, sizeof(buf))) return false;
+  }
+
+  // ---- image ref table ----
+  const uint32_t image_offset = bw_.tell();
+  for (const auto& im : images_) {
+    uint8_t buf[8];
+    cmb_write_u32(buf, im.local_header_offset);
+    cmb_write_u16(buf + 4, im.width);
+    cmb_write_u16(buf + 6, im.height);
+    if (!bw_.write(buf, sizeof(buf))) return false;
+  }
+
+  // ---- anchor table (placeholder for now) ----
+  // v1 reserves the slot; populated in a follow-up commit that adds
+  // anchor collection during EPUB->CMB conversion.
+  const uint32_t anchor_offset = bw_.tell();
+  uint8_t anchor_count_buf[4];
+  cmb_write_u32(anchor_count_buf, 0);
+  if (!bw_.write(anchor_count_buf, sizeof(anchor_count_buf))) return false;
+
+  // ---- metadata + TOC blob ----
+  // Minimal v1 layout:
+  //   title_len:u16, title:bytes
+  //   author_len:u16, author:bytes
+  //   toc_entry_count:u16, toc_entries...  (toc reserved for follow-up)
+  const uint32_t meta_offset = bw_.tell();
+  {
+    uint8_t lenbuf[2];
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_title.size()));
+    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+    if (!metadata_title.empty() && !bw_.write(metadata_title.data(), metadata_title.size())) return false;
+
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_author.size()));
+    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+    if (!metadata_author.empty() && !bw_.write(metadata_author.data(), metadata_author.size())) return false;
+
+    uint8_t toc_count[2];
+    cmb_write_u16(toc_count, 0);
+    if (!bw_.write(toc_count, sizeof(toc_count))) return false;
+  }
+
+  // ---- patch header at offset 0 ----
+  CmbHeader h{};
+  std::memcpy(h.magic, kCmbMagic, sizeof(kCmbMagic));
+  h.version = kCmbVersion;
+  h.flags = 0;
+  h.paragraph_count = paragraph_count_;
+  h.chapter_count = static_cast<uint16_t>(chapters_.size());
+  h.image_count = static_cast<uint16_t>(images_.size());
+  h.anchor_offset = anchor_offset;
+  h.chapter_offset = chapter_offset;
+  h.image_offset = image_offset;
+  h.meta_offset = meta_offset;
+
+  uint8_t header_bytes[32];
+  cmb_write_header(header_bytes, h);
+
+  if (!bw_.seek(0)) return false;
+  if (!bw_.write(header_bytes, sizeof(header_bytes))) return false;
+  if (!bw_.flush()) return false;
+
+  // Don't seek back to end -- caller is expected to close() next.
+  return true;
+}
+
+}  // namespace cmb

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -112,13 +112,28 @@ size_t CmbWriter::serialize_paragraph(const CmbParagraph& p) {
   // Compute payload length first so the {tag, length, payload}
   // envelope is correct -- and so readers can SKIP unknown tags by
   // jumping length bytes forward without parsing the payload.
+  //
+  // Payload sizes per type (in bytes):
+  //   Text:
+  //     alignment(1) + heading_level(1) + text_len(4) + text(N)
+  //       + run_count(2) + runs(R*5) + anchor_id_len(1) + anchor_id(A)
+  //   Image:
+  //     image_key(2) + anchor_id_len(1) + anchor_id(A)
+  //   Hr / PageBreak:
+  //     (empty)
+
+  const size_t anchor_len = p.anchor_id.size();
+  if (anchor_len > 255) return 0;  // anchor_id_len is a u8
+
   uint32_t payload_len = 0;
   switch (p.type) {
     case kCmbBlockText:
-      payload_len = 4 + static_cast<uint32_t>(p.text.size());
+      payload_len = 1 + 1 + 4 + static_cast<uint32_t>(p.text.size()) + 2 +
+                    static_cast<uint32_t>(p.runs.size()) * 5 + 1 +
+                    static_cast<uint32_t>(anchor_len);
       break;
     case kCmbBlockImage:
-      payload_len = 2;
+      payload_len = 2 + 1 + static_cast<uint32_t>(anchor_len);
       break;
     case kCmbBlockHr:
     case kCmbBlockPageBreak:
@@ -126,9 +141,9 @@ size_t CmbWriter::serialize_paragraph(const CmbParagraph& p) {
       break;
     default:
       // Unknown type tag -- writer refuses to emit ambiguous records.
-      // Phase A.1 only knows the four standard tags. Higher-level
-      // converters should map their own block kinds onto these or
-      // negotiate a vendor-extension tag (>= 128) with the format.
+      // Standard tags only; higher-level converters should map their
+      // block kinds onto these or negotiate a vendor-extension tag
+      // (>= 128) with the format.
       return 0;
   }
 
@@ -138,6 +153,7 @@ size_t CmbWriter::serialize_paragraph(const CmbParagraph& p) {
     // than silently truncating.
     return 0;
   }
+  if (p.runs.size() > 0xFFFF) return 0;  // run_count is u16
 
   uint8_t envelope[3];
   envelope[0] = p.type;
@@ -146,18 +162,42 @@ size_t CmbWriter::serialize_paragraph(const CmbParagraph& p) {
 
   switch (p.type) {
     case kCmbBlockText: {
-      uint8_t hdr[4];
-      cmb_write_u32(hdr, static_cast<uint32_t>(p.text.size()));
-      if (!bw_.write(hdr, sizeof(hdr))) return 0;
+      // Fixed-size head: alignment + heading_level + text_len.
+      uint8_t head[6];
+      head[0] = p.alignment;
+      head[1] = p.heading_level;
+      cmb_write_u32(head + 2, static_cast<uint32_t>(p.text.size()));
+      if (!bw_.write(head, sizeof(head))) return 0;
+
+      // Variable-length text body.
       if (!p.text.empty()) {
         if (!bw_.write(p.text.data(), p.text.size())) return 0;
       }
+
+      // Run table.
+      uint8_t run_count_buf[2];
+      cmb_write_u16(run_count_buf, static_cast<uint16_t>(p.runs.size()));
+      if (!bw_.write(run_count_buf, sizeof(run_count_buf))) return 0;
+      for (const auto& r : p.runs) {
+        uint8_t run_buf[5];
+        cmb_write_u16(run_buf, r.start);
+        cmb_write_u16(run_buf + 2, r.length);
+        run_buf[4] = r.style;
+        if (!bw_.write(run_buf, sizeof(run_buf))) return 0;
+      }
+
+      // Trailing anchor_id (length-prefixed u8).
+      uint8_t anchor_len_buf = static_cast<uint8_t>(anchor_len);
+      if (!bw_.write(&anchor_len_buf, 1)) return 0;
+      if (anchor_len > 0 && !bw_.write(p.anchor_id.data(), anchor_len)) return 0;
       break;
     }
     case kCmbBlockImage: {
-      uint8_t hdr[2];
-      cmb_write_u16(hdr, p.image_key);
-      if (!bw_.write(hdr, sizeof(hdr))) return 0;
+      uint8_t head[3];
+      cmb_write_u16(head, p.image_key);
+      head[2] = static_cast<uint8_t>(anchor_len);
+      if (!bw_.write(head, sizeof(head))) return 0;
+      if (anchor_len > 0 && !bw_.write(p.anchor_id.data(), anchor_len)) return 0;
       break;
     }
     case kCmbBlockHr:

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -1,7 +1,6 @@
 #include "CmbWriter.h"
 
 #include <algorithm>
-#include <cstdio>
 #include <cstring>
 
 namespace cmb {
@@ -9,44 +8,81 @@ namespace cmb {
 // ===========================================================================
 // BufferedFileWriter
 // ===========================================================================
+//
+// File backend split: on device the file handle is a HalFile (SdFat-
+// backed; the SD card is only reachable this way -- stdio fopen does
+// not see it because SdFat doesn't register a VFS for libc). On host
+// we keep stdio FILE* so the round-trip test + any future desktop
+// converter compile without dragging Arduino headers in.
+
+namespace {
+
+#ifdef ARDUINO
+// HalFile-backed primitives. Match the FILE* helpers' signatures so
+// the rest of the class can use them through a thin if/then.
+inline bool backend_is_open(const FsFile& f) { return static_cast<bool>(f); }
+inline bool backend_write_raw(FsFile& f, const void* data, size_t size) {
+  return f.write(static_cast<const uint8_t*>(data), size) == size;
+}
+inline bool backend_seek_abs(FsFile& f, uint32_t offset) { return f.seek(offset); }
+inline void backend_close(FsFile& f) { f.close(); }
+#else
+inline bool backend_is_open(FILE* f) { return f != nullptr; }
+inline bool backend_write_raw(FILE* f, const void* data, size_t size) {
+  return std::fwrite(data, 1, size, f) == size;
+}
+inline bool backend_seek_abs(FILE* f, uint32_t offset) {
+  return std::fseek(f, static_cast<long>(offset), SEEK_SET) == 0;
+}
+inline void backend_close(FILE* f) { std::fclose(f); }
+#endif
+
+}  // namespace
+
+bool BufferedFileWriter::is_open() const { return backend_is_open(f_); }
 
 bool BufferedFileWriter::open(const char* path) {
-  if (f_ != nullptr) close();
+  if (is_open()) close();
+#ifdef ARDUINO
+  if (!HalStorage::getInstance().openFileForWrite("CMB", path, f_)) return false;
+#else
   f_ = std::fopen(path, "wb+");
   if (f_ == nullptr) return false;
+#endif
   pos_ = 0;
   used_ = 0;
   return true;
 }
 
 void BufferedFileWriter::close() {
-  if (f_ == nullptr) return;
+  if (!is_open()) return;
   // Best-effort flush; if it fails we still want to close the handle.
   (void)flush();
-  std::fclose(f_);
+  backend_close(f_);
+#ifndef ARDUINO
   f_ = nullptr;
+#endif
   pos_ = 0;
   used_ = 0;
 }
 
 bool BufferedFileWriter::flush() {
-  if (f_ == nullptr) return false;
+  if (!is_open()) return false;
   if (used_ == 0) return true;
-  const size_t written = std::fwrite(buf_, 1, used_, f_);
+  const bool ok = backend_write_raw(f_, buf_, used_);
   used_ = 0;
-  return written != 0;
+  return ok;
 }
 
 bool BufferedFileWriter::write(const void* data, size_t size) {
-  if (f_ == nullptr) return false;
+  if (!is_open()) return false;
   const uint8_t* src = static_cast<const uint8_t*>(data);
 
   while (size > 0) {
     // Fast path: whole big writes that don't fit in the buffer can bypass
     // the buffer entirely once it's been flushed -- saves a copy.
     if (used_ == 0 && size >= kBufSize) {
-      const size_t written = std::fwrite(src, 1, size, f_);
-      if (written != size) return false;
+      if (!backend_write_raw(f_, src, size)) return false;
       pos_ += static_cast<uint32_t>(size);
       return true;
     }
@@ -67,9 +103,9 @@ bool BufferedFileWriter::write(const void* data, size_t size) {
 }
 
 bool BufferedFileWriter::seek(uint32_t offset) {
-  if (f_ == nullptr) return false;
+  if (!is_open()) return false;
   if (!flush()) return false;
-  if (std::fseek(f_, static_cast<long>(offset), SEEK_SET) != 0) return false;
+  if (!backend_seek_abs(f_, offset)) return false;
   pos_ = offset;
   return true;
 }

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -296,6 +296,7 @@ bool CmbWriter::finish(const CmbBookMetadata& metadata) {
   // converter walks book.getSpineItem(i) in order).
   if (!metadata.spine.empty() && metadata.spine.size() != chapters_.size()) return false;
   if (metadata.css_files.size() > 0xFFFF) return false;
+  if (metadata.toc.size() > 0xFFFF) return false;
 
   // ---- chapter table ----
   const uint32_t chapter_offset = bw_.tell();
@@ -363,10 +364,16 @@ bool CmbWriter::finish(const CmbBookMetadata& metadata) {
       if (!write_lp_string_u16(path)) return false;
     }
 
-    // toc_count (stub for v3; v4 will populate the entries here)
-    uint8_t toc_count[2];
-    cmb_write_u16(toc_count, 0);
-    if (!bw_.write(toc_count, sizeof(toc_count))) return false;
+    // toc_count + toc_entries (v4)
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata.toc.size()));
+    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+    for (const CmbTocEntry& entry : metadata.toc) {
+      if (!write_lp_string_u16(entry.title)) return false;
+      if (!write_lp_string_u16(entry.href)) return false;
+      if (!write_lp_string_u16(entry.anchor)) return false;
+      uint8_t lvl = entry.level;
+      if (!bw_.write(&lvl, 1)) return false;
+    }
   }
 
   // ---- patch header at offset 0 ----

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -285,17 +285,17 @@ uint16_t CmbWriter::add_image_ref(uint32_t local_header_offset, uint16_t width, 
   return static_cast<uint16_t>(images_.size() - 1);
 }
 
-bool CmbWriter::finish(const std::string& metadata_title, const std::string& metadata_author,
-                       const std::vector<std::string>& spine_files) {
+bool CmbWriter::finish(const CmbBookMetadata& metadata) {
   if (!bw_.is_open()) return false;
   if (in_chapter_) return false;  // caller forgot end_chapter()
   // Spine count is u16 in the metadata blob.
-  if (spine_files.size() > 0xFFFF) return false;
+  if (metadata.spine.size() > 0xFFFF) return false;
   // The spine table is keyed by chapter index; the two MUST match in
   // length so Epub::load can populate BookMetadataCache one entry
   // per chapter. The caller is responsible (typically the EPUB->.cmb
-  // converter passes book.getSpineItem(i).href in order).
-  if (!spine_files.empty() && spine_files.size() != chapters_.size()) return false;
+  // converter walks book.getSpineItem(i) in order).
+  if (!metadata.spine.empty() && metadata.spine.size() != chapters_.size()) return false;
+  if (metadata.css_files.size() > 0xFFFF) return false;
 
   // ---- chapter table ----
   const uint32_t chapter_offset = bw_.tell();
@@ -327,42 +327,43 @@ bool CmbWriter::finish(const std::string& metadata_title, const std::string& met
   cmb_write_u32(anchor_count_buf, 0);
   if (!bw_.write(anchor_count_buf, sizeof(anchor_count_buf))) return false;
 
-  // ---- metadata + TOC blob (v2 layout) ----
-  //   title_len:u16, title:bytes
-  //   author_len:u16, author:bytes
-  //   spine_count:u16
-  //   spine_entries[spine_count]: { href_len:u16, href:bytes }
-  //   toc_count:u16, toc_entries... (TOC entries stub for v2; populated
-  //                                  in a later format bump)
-  //
-  // v1 stored only title + author + (mislabelled) toc_count. v2 inserts
-  // the spine table between author and toc_count -- v1 readers fail the
-  // version check and bail before reaching this blob.
+  // ---- metadata + TOC blob (v3 layout, see CmbFormat.h docs) ----
   const uint32_t meta_offset = bw_.tell();
   {
-    uint8_t lenbuf[2];
+    auto write_lp_string_u16 = [&](const std::string& s) -> bool {
+      if (s.size() > 0xFFFF) return false;
+      uint8_t lenbuf[2];
+      cmb_write_u16(lenbuf, static_cast<uint16_t>(s.size()));
+      if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+      if (!s.empty() && !bw_.write(s.data(), s.size())) return false;
+      return true;
+    };
 
-    // title
-    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_title.size()));
-    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
-    if (!metadata_title.empty() && !bw_.write(metadata_title.data(), metadata_title.size())) return false;
-
-    // author
-    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata_author.size()));
-    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
-    if (!metadata_author.empty() && !bw_.write(metadata_author.data(), metadata_author.size())) return false;
+    if (!write_lp_string_u16(metadata.title)) return false;
+    if (!write_lp_string_u16(metadata.author)) return false;
+    if (!write_lp_string_u16(metadata.language)) return false;
+    if (!write_lp_string_u16(metadata.cover_href)) return false;
+    if (!write_lp_string_u16(metadata.text_reference_href)) return false;
 
     // spine_count + spine_entries
-    cmb_write_u16(lenbuf, static_cast<uint16_t>(spine_files.size()));
+    uint8_t lenbuf[2];
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata.spine.size()));
     if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
-    for (const std::string& href : spine_files) {
-      if (href.size() > 0xFFFF) return false;  // href_len is u16
-      cmb_write_u16(lenbuf, static_cast<uint16_t>(href.size()));
-      if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
-      if (!href.empty() && !bw_.write(href.data(), href.size())) return false;
+    for (const CmbSpineEntry& entry : metadata.spine) {
+      if (!write_lp_string_u16(entry.href)) return false;
+      uint8_t cum_buf[4];
+      cmb_write_u32(cum_buf, entry.cumulative_size);
+      if (!bw_.write(cum_buf, sizeof(cum_buf))) return false;
     }
 
-    // toc_count (stub)
+    // css_count + css_files
+    cmb_write_u16(lenbuf, static_cast<uint16_t>(metadata.css_files.size()));
+    if (!bw_.write(lenbuf, sizeof(lenbuf))) return false;
+    for (const std::string& path : metadata.css_files) {
+      if (!write_lp_string_u16(path)) return false;
+    }
+
+    // toc_count (stub for v3; v4 will populate the entries here)
     uint8_t toc_count[2];
     cmb_write_u16(toc_count, 0);
     if (!bw_.write(toc_count, sizeof(toc_count))) return false;

--- a/lib/Cmb/CmbWriter.cpp
+++ b/lib/Cmb/CmbWriter.cpp
@@ -43,6 +43,13 @@ bool BufferedFileWriter::is_open() const { return backend_is_open(f_); }
 
 bool BufferedFileWriter::open(const char* path) {
   if (is_open()) close();
+  // Heap-allocate the 4 KB scratch buffer. Keeping it inline in the
+  // class blew the Arduino loopTask stack (8 KB) when CmbWriter was
+  // a local in convert_epub_to_cmb, on top of Activity / Epub::load.
+  if (!buf_) {
+    buf_.reset(new (std::nothrow) uint8_t[kBufSize]);
+    if (!buf_) return false;
+  }
 #ifdef ARDUINO
   if (!HalStorage::getInstance().openFileForWrite("CMB", path, f_)) return false;
 #else
@@ -64,12 +71,14 @@ void BufferedFileWriter::close() {
 #endif
   pos_ = 0;
   used_ = 0;
+  // Release the 4 KB scratch buffer; next open() reallocates.
+  buf_.reset();
 }
 
 bool BufferedFileWriter::flush() {
   if (!is_open()) return false;
   if (used_ == 0) return true;
-  const bool ok = backend_write_raw(f_, buf_, used_);
+  const bool ok = backend_write_raw(f_, buf_.get(), used_);
   used_ = 0;
   return ok;
 }
@@ -89,7 +98,7 @@ bool BufferedFileWriter::write(const void* data, size_t size) {
 
     const size_t room = kBufSize - used_;
     const size_t copy = (size < room) ? size : room;
-    std::memcpy(buf_ + used_, src, copy);
+    std::memcpy(buf_.get() + used_, src, copy);
     used_ += copy;
     src += copy;
     size -= copy;

--- a/lib/Cmb/CmbWriter.h
+++ b/lib/Cmb/CmbWriter.h
@@ -1,0 +1,136 @@
+#pragma once
+
+// CmbWriter -- streaming write of the CrumBLE .cmb compact-binary book
+// format. Usage:
+//
+//   cmb::CmbWriter w;
+//   if (!w.open("book.cmb")) { ... }
+//
+//   for (each chapter) {
+//     w.begin_chapter();
+//     for (each paragraph) w.write_paragraph(p);
+//     w.end_chapter();
+//   }
+//
+//   for (each image) w.add_image_ref(local_header_offset, w, h);
+//
+//   w.finish(metadata_title, metadata_author);
+//   w.close();
+//
+// Internally backed by a 4 KB BufferedFileWriter that batches small
+// writes. Chapter content blobs are written sequentially (no backward
+// seeks during chapter content). All tables (per-chapter descriptors,
+// chapter table, image refs, metadata) are written AFTER all chapter
+// content, then the 32-byte header is patched in at file offset 0 in
+// a single seek-and-write.
+//
+// Heap budget: ~4 KB write buffer + transient vectors for the chapter
+// table + image refs (~16 + 8 bytes per entry, allocated as the writer
+// runs). For a 377-chapter War-and-Peace EPUB that's ~6 KB peak, well
+// under the worst-case on-device budget.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "CmbFormat.h"
+
+namespace cmb {
+
+// 4 KB write-buffered FILE* wrapper. Only used internally by CmbWriter
+// (lifecycle is bound to it) but exposed in this header so unit tests
+// can directly exercise the buffering / seek behavior if needed.
+class BufferedFileWriter {
+ public:
+  BufferedFileWriter() = default;
+  ~BufferedFileWriter() { close(); }
+  BufferedFileWriter(const BufferedFileWriter&) = delete;
+  BufferedFileWriter& operator=(const BufferedFileWriter&) = delete;
+
+  bool open(const char* path);
+  void close();
+  bool is_open() const { return f_ != nullptr; }
+
+  // Buffered byte write. Returns false on I/O failure.
+  bool write(const void* data, size_t size);
+
+  // Flush the buffer to the underlying FILE*. Called automatically on
+  // close(); callers usually don't need this except before a seek().
+  bool flush();
+
+  // Move the file cursor. Flushes the buffer first so subsequent writes
+  // land at the new position. Used by CmbWriter::finish() to patch
+  // in the header at file offset 0.
+  bool seek(uint32_t offset);
+
+  // Current logical file position (post-buffer). O(1).
+  uint32_t tell() const { return pos_; }
+
+ private:
+  static constexpr size_t kBufSize = 4096;
+  FILE* f_ = nullptr;
+  uint32_t pos_ = 0;
+  size_t used_ = 0;
+  uint8_t buf_[kBufSize] = {};
+};
+
+class CmbWriter {
+ public:
+  CmbWriter() = default;
+  ~CmbWriter() { close(); }
+  CmbWriter(const CmbWriter&) = delete;
+  CmbWriter& operator=(const CmbWriter&) = delete;
+
+  bool open(const char* path);
+  void close();
+  bool is_open() const { return bw_.is_open(); }
+
+  // Chapter management. begin_chapter() resets per-chapter state;
+  // every write_paragraph() between begin/end appends to the current
+  // chapter's content blob. end_chapter() flushes the chapter's
+  // descriptor table (file_offset + char_offset per paragraph) and
+  // records the chapter's table entry.
+  void begin_chapter();
+  bool write_paragraph(const CmbParagraph& p);
+  void end_chapter();
+
+  // Image reference table. Add one entry per image referenced by any
+  // paragraph in the book. Returns the image index to put in the
+  // paragraph's image_key field. Idempotent on the (offset, w, h)
+  // tuple -- duplicate adds return the same index.
+  uint16_t add_image_ref(uint32_t local_header_offset, uint16_t width, uint16_t height);
+
+  // Final pass: writes all the tables (per-chapter descriptors,
+  // chapter table, image refs, metadata) and patches the header in
+  // at offset 0. Must be called once after all chapters are done;
+  // subsequent close() will leave the file valid.
+  bool finish(const std::string& metadata_title, const std::string& metadata_author);
+
+ private:
+  BufferedFileWriter bw_;
+
+  // Total paragraph count across all chapters (header.paragraph_count).
+  uint32_t paragraph_count_ = 0;
+
+  // Per-chapter table -- built as we go, written in finish().
+  std::vector<CmbChapterEntry> chapters_;
+
+  // Per-image table -- built as add_image_ref() is called, written in finish().
+  std::vector<CmbImageRef> images_;
+
+  // Per-chapter descriptor table, accumulating during begin_chapter ..
+  // end_chapter. end_chapter() writes this to disk (at the chapter's
+  // para_table_offset) and clears the vector for the next chapter.
+  std::vector<CmbParaDescriptor> current_chapter_descriptors_;
+  uint32_t current_chapter_char_count_ = 0;
+  bool in_chapter_ = false;
+
+  // Serializes a paragraph to its on-disk tagged-record encoding and
+  // writes to bw_. Returns the byte length actually written (so the
+  // caller can update char_offset accumulators). Returns 0 on I/O
+  // error; check bw_.is_open() to disambiguate from "empty record".
+  size_t serialize_paragraph(const CmbParagraph& p);
+};
+
+}  // namespace cmb

--- a/lib/Cmb/CmbWriter.h
+++ b/lib/Cmb/CmbWriter.h
@@ -30,6 +30,7 @@
 // under the worst-case on-device budget.
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -87,7 +88,11 @@ class BufferedFileWriter {
 #endif
   uint32_t pos_ = 0;
   size_t used_ = 0;
-  uint8_t buf_[kBufSize] = {};
+  // Heap-backed; allocated on open(), released on close(). Inline 4 KB
+  // would blow the Arduino loopTask stack (~8 KB) when CmbWriter is
+  // instantiated as a local in convert_epub_to_cmb on top of an
+  // Activity / Epub::load call chain.
+  std::unique_ptr<uint8_t[]> buf_;
 };
 
 class CmbWriter {

--- a/lib/Cmb/CmbWriter.h
+++ b/lib/Cmb/CmbWriter.h
@@ -106,13 +106,13 @@ class CmbWriter {
   // at offset 0. Must be called once after all chapters are done;
   // subsequent close() will leave the file valid.
   //
-  // spine_files MUST be `chapter_count`-long (one href per chapter,
-  // in spine order). These are the EPUB-internal paths the reader
-  // uses to identify chapter content -- v2 of the format carries
-  // them so `Epub::load()` can populate `BookMetadataCache` from
-  // the .cmb without re-parsing content.opf.
-  bool finish(const std::string& metadata_title, const std::string& metadata_author,
-              const std::vector<std::string>& spine_files);
+  // `metadata.spine` MUST be `chapter_count`-long (one entry per
+  // chapter, in spine order). The full BookMetadataCache set --
+  // title, author, language, cover/text-ref hrefs, spine cumulative
+  // sizes, CSS files -- gets serialised so `Epub::load()` can
+  // populate the metadata cache directly from .cmb without parsing
+  // the EPUB ZIP central directory + content.opf.
+  bool finish(const CmbBookMetadata& metadata);
 
  private:
   BufferedFileWriter bw_;

--- a/lib/Cmb/CmbWriter.h
+++ b/lib/Cmb/CmbWriter.h
@@ -105,7 +105,14 @@ class CmbWriter {
   // chapter table, image refs, metadata) and patches the header in
   // at offset 0. Must be called once after all chapters are done;
   // subsequent close() will leave the file valid.
-  bool finish(const std::string& metadata_title, const std::string& metadata_author);
+  //
+  // spine_files MUST be `chapter_count`-long (one href per chapter,
+  // in spine order). These are the EPUB-internal paths the reader
+  // uses to identify chapter content -- v2 of the format carries
+  // them so `Epub::load()` can populate `BookMetadataCache` from
+  // the .cmb without re-parsing content.opf.
+  bool finish(const std::string& metadata_title, const std::string& metadata_author,
+              const std::vector<std::string>& spine_files);
 
  private:
   BufferedFileWriter bw_;

--- a/lib/Cmb/CmbWriter.h
+++ b/lib/Cmb/CmbWriter.h
@@ -30,17 +30,28 @@
 // under the worst-case on-device budget.
 
 #include <cstdint>
-#include <cstdio>
 #include <string>
 #include <vector>
+
+#ifdef ARDUINO
+// On-device: route file I/O through the SdFat-backed HalStorage layer.
+// stdio fopen/fwrite don't work because SdFat doesn't register itself
+// as a VFS for libc -- the SD card is only reachable through HalFile.
+#include <HalStorage.h>
+#else
+// Host-side (unit tests, prospective desktop converter): plain stdio.
+#include <cstdio>
+#endif
 
 #include "CmbFormat.h"
 
 namespace cmb {
 
-// 4 KB write-buffered FILE* wrapper. Only used internally by CmbWriter
-// (lifecycle is bound to it) but exposed in this header so unit tests
-// can directly exercise the buffering / seek behavior if needed.
+// 4 KB write-buffered file wrapper. On device the backing file is a
+// HalFile (SdFat); on host it's a stdio FILE*. The split is hidden
+// behind a single member type so the rest of CmbWriter doesn't care.
+// Exposed in this header so unit tests can directly exercise the
+// buffering / seek behavior if needed.
 class BufferedFileWriter {
  public:
   BufferedFileWriter() = default;
@@ -50,12 +61,12 @@ class BufferedFileWriter {
 
   bool open(const char* path);
   void close();
-  bool is_open() const { return f_ != nullptr; }
+  bool is_open() const;
 
   // Buffered byte write. Returns false on I/O failure.
   bool write(const void* data, size_t size);
 
-  // Flush the buffer to the underlying FILE*. Called automatically on
+  // Flush the buffer to the underlying file. Called automatically on
   // close(); callers usually don't need this except before a seek().
   bool flush();
 
@@ -69,7 +80,11 @@ class BufferedFileWriter {
 
  private:
   static constexpr size_t kBufSize = 4096;
+#ifdef ARDUINO
+  FsFile f_;
+#else
   FILE* f_ = nullptr;
+#endif
   uint32_t pos_ = 0;
   size_t used_ = 0;
   uint8_t buf_[kBufSize] = {};

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -625,6 +625,11 @@ bool Epub::extractSeriesFromOpf() {
 bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   LOG_DBG("EBP", "Loading ePub: %s", filepath.c_str());
 
+  // One-shot: move any pre-existing legacy `foo.cmb` sibling into the
+  // per-book cache directory. After this, the rest of the load path
+  // only ever looks at the new location (getCmbPath()).
+  migrateLegacyCmbSidecar();
+
   // Initialize spine/TOC cache
   bookMetadataCache.reset(new BookMetadataCache(cachePath));
   // Always create CssParser - needed for inline style parsing even without CSS files
@@ -1221,13 +1226,20 @@ const std::string& Epub::getTextReferenceHref() const {
   return bookMetadataCache->coreMetadata.textReferenceHref;
 }
 
-std::string Epub::deriveCmbPath(const std::string& epubPath) {
-  // foo.epub -> foo.cmb. Mirrors the .pxc derivation pattern in
-  // ImageBlock (replace the extension); not "foo.epub.cmb" so user-
-  // visible names stay clean.
+std::string Epub::getCmbPath() const {
+  // Lives inside the per-book cache directory next to book.bin so the
+  // sidecar never appears next to user-visible .epub files on the SD
+  // card. Constant filename within the dir because the directory path
+  // already encodes the book identity (hash of the epub path).
+  if (cachePath.empty()) return {};
+  return cachePath + "/book.cmb";
+}
+
+std::string Epub::legacyCmbSiblingPath(const std::string& epubPath) {
+  // Legacy: `foo.epub` -> `foo.cmb` (sibling). Used by the original
+  // CrumBLE alpha builds before we moved the sidecar into the cache
+  // dir. Kept ONLY for migration.
   const size_t dot = epubPath.rfind('.');
-  // Also confirm the dot is past the last path separator so we don't
-  // mangle paths like "/foo.dir/book" (no extension).
   const size_t slash = epubPath.find_last_of("/\\");
   if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) {
     return {};
@@ -1235,8 +1247,41 @@ std::string Epub::deriveCmbPath(const std::string& epubPath) {
   return epubPath.substr(0, dot) + ".cmb";
 }
 
+void Epub::migrateLegacyCmbSidecar() {
+  const std::string legacyPath = legacyCmbSiblingPath(filepath);
+  if (legacyPath.empty() || !Storage.exists(legacyPath.c_str())) return;
+
+  const std::string newPath = getCmbPath();
+  if (newPath.empty()) return;
+
+  // If the new (cache-dir) copy already exists, the legacy sibling is
+  // an orphan from an earlier alpha install -- delete it. Otherwise
+  // move it into the cache dir so the user doesn't pay a re-conversion
+  // cost just for the path change.
+  if (Storage.exists(newPath.c_str())) {
+    if (Storage.remove(legacyPath.c_str())) {
+      LOG_INF("EBP", "Removed orphan .cmb sidecar: %s", legacyPath.c_str());
+    } else {
+      LOG_ERR("EBP", "Failed to remove orphan .cmb sidecar: %s", legacyPath.c_str());
+    }
+    return;
+  }
+
+  // Need the cache dir to exist before we can rename into it.
+  setupCacheDir();
+  if (Storage.rename(legacyPath.c_str(), newPath.c_str())) {
+    LOG_INF("EBP", "Migrated .cmb sidecar into cache: %s -> %s", legacyPath.c_str(), newPath.c_str());
+  } else {
+    LOG_ERR("EBP", "Failed to migrate .cmb sidecar (%s -> %s); removing legacy file", legacyPath.c_str(),
+            newPath.c_str());
+    // Best effort: delete the legacy file. Next book open will rebuild
+    // the .cmb at the new location from the EPUB.
+    Storage.remove(legacyPath.c_str());
+  }
+}
+
 bool Epub::tryLoadFromCmb(const bool skipLoadingCss) {
-  const std::string cmbPath = deriveCmbPath(filepath);
+  const std::string cmbPath = getCmbPath();
   if (cmbPath.empty() || !Storage.exists(cmbPath.c_str())) return false;
 
   cmb::CmbReader reader;
@@ -1333,9 +1378,11 @@ bool Epub::tryLoadFromCmb(const bool skipLoadingCss) {
 }
 
 bool Epub::ensureCmbExists() {
-  const std::string cmbPath = deriveCmbPath(filepath);
+  const std::string cmbPath = getCmbPath();
   if (cmbPath.empty()) return false;
   if (Storage.exists(cmbPath.c_str())) return true;
+  // Need the cache dir to exist before writing the sidecar into it.
+  setupCacheDir();
 
   // Conversion needs bookMetadataCache loaded (the converter reads
   // spine + metadata via Epub accessors which all go through the

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1381,6 +1381,24 @@ bool Epub::ensureCmbExists() {
   const std::string cmbPath = getCmbPath();
   if (cmbPath.empty()) return false;
   if (Storage.exists(cmbPath.c_str())) return true;
+
+  // CrumBLE: heap precheck. The converter peaks at ~30 KB of working
+  // memory (one chapter's raw XHTML + expat state + write buffer +
+  // metadata accumulators), and an uncaught std::bad_alloc inside
+  // std::vector reserve / operator new takes the process down via
+  // std::terminate -> abort. The .cmb sidecar is purely opportunistic
+  // -- if we can't fit the conversion now, skip and try again on a
+  // future open when memory has recovered.
+  constexpr uint32_t kMinFreeHeap = 70 * 1024;
+  constexpr uint32_t kMinMaxAlloc = 40 * 1024;
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  const uint32_t maxAlloc = ESP.getMaxAllocHeap();
+  if (freeHeap < kMinFreeHeap || maxAlloc < kMinMaxAlloc) {
+    LOG_DBG("EBP", "ensureCmbExists: heap too tight (free=%u maxAlloc=%u min=%u/%u); skipping", freeHeap, maxAlloc,
+            kMinFreeHeap, kMinMaxAlloc);
+    return false;
+  }
+
   // Need the cache dir to exist before writing the sidecar into it.
   setupCacheDir();
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1389,12 +1389,20 @@ bool Epub::ensureCmbExists() {
   // std::terminate -> abort. The .cmb sidecar is purely opportunistic
   // -- if we can't fit the conversion now, skip and try again on a
   // future open when memory has recovered.
-  constexpr uint32_t kMinFreeHeap = 70 * 1024;
-  constexpr uint32_t kMinMaxAlloc = 40 * 1024;
+  //
+  // Thresholds tuned from device observation: at book-open time after
+  // a few navigations + CSS load, maxAlloc commonly sits ~32-40 KB and
+  // free ~80 KB. A 40 KB maxAlloc gate was blocking every conversion
+  // in practice. Lower to 28 KB maxAlloc / 60 KB free -- this lets the
+  // conversion actually fire in typical sessions; the worst case is
+  // still a clean skip with a logged line. Bumped to INF so it's
+  // visible without LOG_LEVEL=2.
+  constexpr uint32_t kMinFreeHeap = 60 * 1024;
+  constexpr uint32_t kMinMaxAlloc = 28 * 1024;
   const uint32_t freeHeap = ESP.getFreeHeap();
   const uint32_t maxAlloc = ESP.getMaxAllocHeap();
   if (freeHeap < kMinFreeHeap || maxAlloc < kMinMaxAlloc) {
-    LOG_DBG("EBP", "ensureCmbExists: heap too tight (free=%u maxAlloc=%u min=%u/%u); skipping", freeHeap, maxAlloc,
+    LOG_INF("EBP", "ensureCmbExists: heap too tight (free=%u maxAlloc=%u min=%u/%u); skipping", freeHeap, maxAlloc,
             kMinFreeHeap, kMinMaxAlloc);
     return false;
   }

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1174,6 +1174,12 @@ bool Epub::getItemSize(const std::string& itemHref, size_t* size) const {
   return ZipFile(filepath).getInflatedFileSize(path.c_str(), size);
 }
 
+bool Epub::getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset) const {
+  if (itemHref.empty() || offset == nullptr) return false;
+  const std::string path = FsHelpers::normalisePath(itemHref);
+  return ZipFile(filepath).getLocalHeaderOffset(path.c_str(), offset);
+}
+
 bool Epub::isItemStored(const std::string& itemHref) const {
   const std::string path = FsHelpers::normalisePath(itemHref);
   uint16_t method = 0xFFFF;

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1,5 +1,6 @@
 #include "Epub.h"
 
+#include <CmbConverter.h>
 #include <CmbReader.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
@@ -647,6 +648,11 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
       }
     }
     LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
+    // CrumBLE #134: opportunistic .cmb write. No-op on subsequent
+    // book-bin reloads (file already exists). On post-cache-clear
+    // reload it'd be slow but the user just cleared their cache, so
+    // they're already in "this is going to take a moment" territory.
+    ensureCmbExists();
     return true;
   }
 
@@ -763,6 +769,12 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   }
 
   LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
+  // CrumBLE #134: after a successful slow-path build, write a .cmb
+  // sidecar so the next post-cache-clear reopen (or any user with
+  // multiple devices sharing the SD) hits the fast path. Synchronous
+  // here -- the slow path already took several seconds on big books,
+  // so the additional conversion time is in similar territory.
+  ensureCmbExists();
   return true;
 }
 
@@ -1317,6 +1329,39 @@ bool Epub::tryLoadFromCmb(const bool skipLoadingCss) {
     parseCssFiles();
     Storage.removeDir((cachePath + "/sections").c_str());
   }
+  return true;
+}
+
+bool Epub::ensureCmbExists() {
+  const std::string cmbPath = deriveCmbPath(filepath);
+  if (cmbPath.empty()) return false;
+  if (Storage.exists(cmbPath.c_str())) return true;
+
+  // Conversion needs bookMetadataCache loaded (the converter reads
+  // spine + metadata via Epub accessors which all go through the
+  // cache). Bail rather than write a broken .cmb.
+  if (!bookMetadataCache || !bookMetadataCache->isLoaded()) {
+    LOG_DBG("EBP", "ensureCmbExists: cache not loaded; skipping");
+    return false;
+  }
+
+  const uint32_t start = millis();
+  LOG_DBG("EBP", "ensureCmbExists: converting %s -> %s", filepath.c_str(), cmbPath.c_str());
+
+  const bool ok = cmb::convert_epub_to_cmb(*this, cmbPath.c_str());
+  if (!ok) {
+    LOG_ERR("EBP", "ensureCmbExists: conversion failed for %s", filepath.c_str());
+    // Remove any partial output so the next call retries cleanly. If
+    // the file was created and partially written before failure, the
+    // CmbReader's magic-check would reject it; but cleaning up keeps
+    // SD tidy.
+    if (Storage.exists(cmbPath.c_str())) {
+      Storage.remove(cmbPath.c_str());
+    }
+    return false;
+  }
+
+  LOG_INF("EBP", "ensureCmbExists: wrote .cmb in %lu ms: %s", millis() - start, cmbPath.c_str());
   return true;
 }
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1,5 +1,6 @@
 #include "Epub.h"
 
+#include <CmbReader.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <JpegToBmpConverter.h>
@@ -654,6 +655,20 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
     return false;
   }
 
+  // CrumBLE #134: try the .cmb sidecar fast path before doing the
+  // full EPUB ZIP + content.opf parse. On a hit we get to skip:
+  //   - ZIP central-dir walk (~30 KB on big books)
+  //   - content.opf XML parse
+  //   - TOC NCX / nav XML parse
+  //   - CSS rule build (the .cmb carries the CSS file list so we
+  //     can still parse them on first open, but the metadata
+  //     gather pass is gone)
+  // Falls through to the slow path on any failure.
+  if (tryLoadFromCmb(skipLoadingCss)) {
+    LOG_DBG("EBP", "Loaded ePub via .cmb fast path: %s", filepath.c_str());
+    return true;
+  }
+
   // Cache doesn't exist or is invalid, build it
   LOG_DBG("EBP", "Cache not found, building spine/TOC cache");
   setupCacheDir();
@@ -1192,6 +1207,117 @@ const std::string& Epub::getCoverItemHref() const {
 const std::string& Epub::getTextReferenceHref() const {
   if (!bookMetadataCache || !bookMetadataCache->isLoaded()) return kEmptyString;
   return bookMetadataCache->coreMetadata.textReferenceHref;
+}
+
+std::string Epub::deriveCmbPath(const std::string& epubPath) {
+  // foo.epub -> foo.cmb. Mirrors the .pxc derivation pattern in
+  // ImageBlock (replace the extension); not "foo.epub.cmb" so user-
+  // visible names stay clean.
+  const size_t dot = epubPath.rfind('.');
+  // Also confirm the dot is past the last path separator so we don't
+  // mangle paths like "/foo.dir/book" (no extension).
+  const size_t slash = epubPath.find_last_of("/\\");
+  if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) {
+    return {};
+  }
+  return epubPath.substr(0, dot) + ".cmb";
+}
+
+bool Epub::tryLoadFromCmb(const bool skipLoadingCss) {
+  const std::string cmbPath = deriveCmbPath(filepath);
+  if (cmbPath.empty() || !Storage.exists(cmbPath.c_str())) return false;
+
+  cmb::CmbReader reader;
+  if (!reader.open(cmbPath.c_str())) {
+    LOG_DBG("EBP", ".cmb open failed: %s", cmbPath.c_str());
+    return false;
+  }
+  const cmb::CmbBookMetadata& md = reader.metadata();
+  if (md.spine.empty()) {
+    LOG_DBG("EBP", ".cmb has empty spine; falling back to slow path: %s", cmbPath.c_str());
+    return false;
+  }
+
+  setupCacheDir();
+
+  // Populate BookMetadataCache via its builder API. Same call shape
+  // as the slow path's beginWrite -> spine/TOC -> endWrite -> buildBookBin,
+  // just sourced from .cmb instead of EPUB parsing.
+  if (!bookMetadataCache->beginWrite()) {
+    LOG_ERR("EBP", ".cmb fast path: beginWrite failed");
+    return false;
+  }
+  if (!bookMetadataCache->beginContentOpfPass()) {
+    LOG_ERR("EBP", ".cmb fast path: beginContentOpfPass failed");
+    return false;
+  }
+  for (const auto& entry : md.spine) {
+    bookMetadataCache->createSpineEntry(entry.href);
+  }
+  if (!bookMetadataCache->endContentOpfPass()) {
+    LOG_ERR("EBP", ".cmb fast path: endContentOpfPass failed");
+    return false;
+  }
+  if (!bookMetadataCache->beginTocPass()) {
+    LOG_ERR("EBP", ".cmb fast path: beginTocPass failed");
+    return false;
+  }
+  for (const auto& entry : md.toc) {
+    bookMetadataCache->createTocEntry(entry.title, entry.href, entry.anchor, entry.level);
+  }
+  if (!bookMetadataCache->endTocPass()) {
+    LOG_ERR("EBP", ".cmb fast path: endTocPass failed");
+    return false;
+  }
+  if (!bookMetadataCache->endWrite()) {
+    LOG_ERR("EBP", ".cmb fast path: endWrite failed");
+    return false;
+  }
+
+  // Populate the BookMetadata struct + pre-computed cumulative sizes
+  // for buildBookBin. The precomputed vector lets buildBookBin skip
+  // the ZIP central-dir walk -- the actual heap-win lever.
+  BookMetadataCache::BookMetadata bookMetadata;
+  bookMetadata.title = md.title;
+  bookMetadata.author = md.author;
+  bookMetadata.language = md.language;
+  bookMetadata.coverItemHref = md.cover_href;
+  bookMetadata.textReferenceHref = md.text_reference_href;
+
+  std::deque<uint32_t> sizes;
+  sizes.resize(md.spine.size());
+  for (size_t i = 0; i < md.spine.size(); ++i) sizes[i] = md.spine[i].cumulative_size;
+
+  if (!bookMetadataCache->buildBookBin(filepath, bookMetadata, &sizes)) {
+    LOG_ERR("EBP", ".cmb fast path: buildBookBin failed");
+    return false;
+  }
+
+  if (!bookMetadataCache->cleanupTmpFiles()) {
+    LOG_DBG("EBP", ".cmb fast path: cleanupTmpFiles ignored failure");
+  }
+
+  // Reload the cache from disk so its in-memory state matches what
+  // the slow path leaves behind.
+  bookMetadataCache.reset(new BookMetadataCache(cachePath));
+  if (!bookMetadataCache->load()) {
+    LOG_ERR("EBP", ".cmb fast path: post-build reload failed");
+    return false;
+  }
+
+  // Hand the CSS file list to the EPUB instance so parseCssFiles
+  // knows what to walk on first open. Note: parseCssFiles still
+  // reads the actual CSS bytes from the EPUB ZIP -- the .cmb only
+  // tells us WHICH files to read. Saving the per-file parse cost
+  // would require embedding parsed CSS rules in .cmb (a future
+  // format bump).
+  cssFiles = md.css_files;
+
+  if (!skipLoadingCss) {
+    parseCssFiles();
+    Storage.removeDir((cachePath + "/sections").c_str());
+  }
+  return true;
 }
 
 bool Epub::isItemStored(const std::string& itemHref) const {

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1180,6 +1180,20 @@ bool Epub::getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset
   return ZipFile(filepath).getLocalHeaderOffset(path.c_str(), offset);
 }
 
+namespace {
+const std::string kEmptyString;
+}  // namespace
+
+const std::string& Epub::getCoverItemHref() const {
+  if (!bookMetadataCache || !bookMetadataCache->isLoaded()) return kEmptyString;
+  return bookMetadataCache->coreMetadata.coverItemHref;
+}
+
+const std::string& Epub::getTextReferenceHref() const {
+  if (!bookMetadataCache || !bookMetadataCache->isLoaded()) return kEmptyString;
+  return bookMetadataCache->coreMetadata.textReferenceHref;
+}
+
 bool Epub::isItemStored(const std::string& itemHref) const {
   const std::string path = FsHelpers::normalisePath(itemHref);
   uint16_t method = 0xFFFF;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -42,6 +42,16 @@ class Epub {
   bool parseTocNcxFile() const;
   bool parseTocNavFile() const;
   void parseCssFiles() const;
+  // CrumBLE #134: cold-open fast path. If a .cmb sidecar lives next
+  // to the EPUB, populates `bookMetadataCache` from it (no ZIP +
+  // OPF + CSS + TOC parse) and returns true. Returns false on any
+  // failure -- caller falls through to the slow path. Side-effects
+  // mirror the slow path's: bookMetadataCache is loaded, cssFiles
+  // is set, sections cache is invalidated if !skipLoadingCss.
+  bool tryLoadFromCmb(bool skipLoadingCss);
+  // Sibling path: `foo.epub` -> `foo.cmb`. Returns empty when the
+  // input has no detectable extension.
+  static std::string deriveCmbPath(const std::string& epubPath);
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir);

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -49,13 +49,15 @@ class Epub {
   // mirror the slow path's: bookMetadataCache is loaded, cssFiles
   // is set, sections cache is invalidated if !skipLoadingCss.
   bool tryLoadFromCmb(bool skipLoadingCss);
-  // Sibling path: `foo.epub` -> `foo.cmb`. Returns empty when the
-  // input has no detectable extension.
-  static std::string deriveCmbPath(const std::string& epubPath);
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir);
   ~Epub() = default;
+  // Sibling path: `foo.epub` -> `foo.cmb`. Returns empty when the
+  // input has no detectable extension. Public so other parts of the
+  // reader (e.g. Section::createSectionFile's CMB fast-path dispatch)
+  // can locate the sidecar without re-implementing the suffix swap.
+  static std::string deriveCmbPath(const std::string& epubPath);
   static std::string cachePathForFilePath(const std::string& filepath, const std::string& cacheDir);
   std::string& getBasePath() { return contentBasePath; }
   bool load(bool buildIfMissing = true, bool skipLoadingCss = false);

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -110,6 +110,12 @@ class Epub {
                                    bool trailingNullByte = false) const;
   bool readItemContentsToStream(const std::string& itemHref, Print& out, size_t chunkSize) const;
   bool getItemSize(const std::string& itemHref, size_t* size) const;
+  // CrumBLE #134: look up an item's local-file-header offset in the
+  // EPUB ZIP. Used by the .cmb converter to record image refs --
+  // stored as offsets instead of paths so the reader can pull image
+  // bytes from the EPUB without walking the central directory at
+  // display time. Path normalised the same way as readItemContents*.
+  bool getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset) const;
   // CrumBLE: true if the item is STORED (uncompressed) in the EPUB zip. A STORED
   // chapter needs no 32 KB DEFLATE window to cold-load, so the reader can build
   // it in place while BLE is connected instead of dropping/re-enabling BLE

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -116,6 +116,14 @@ class Epub {
   // bytes from the EPUB without walking the central directory at
   // display time. Path normalised the same way as readItemContents*.
   bool getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset) const;
+  // CrumBLE #134: accessors for metadata fields the .cmb converter
+  // needs to capture into the .cmb v3 metadata blob. Cover href and
+  // text-reference href live inside the BookMetadataCache; the CSS
+  // files vector lives on Epub itself. Pure additions; no
+  // behavioural change for existing callers.
+  const std::string& getCoverItemHref() const;
+  const std::string& getTextReferenceHref() const;
+  const std::vector<std::string>& getCssFiles() const { return cssFiles; }
   // CrumBLE: true if the item is STORED (uncompressed) in the EPUB zip. A STORED
   // chapter needs no 32 KB DEFLATE window to cold-load, so the reader can build
   // it in place while BLE is connected instead of dropping/re-enabling BLE

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -49,15 +49,27 @@ class Epub {
   // mirror the slow path's: bookMetadataCache is loaded, cssFiles
   // is set, sections cache is invalidated if !skipLoadingCss.
   bool tryLoadFromCmb(bool skipLoadingCss);
+  // Legacy sibling layout used in early CrumBLE builds: `foo.epub` ->
+  // `foo.cmb` next to the original. Visible to anyone mounting the SD
+  // card, which is confusing. Kept ONLY so migrateLegacyCmbSidecar()
+  // can find old files and move them into the per-book cache dir.
+  // Returns empty when the input has no detectable extension.
+  static std::string legacyCmbSiblingPath(const std::string& epubPath);
+  // If a legacy sibling `foo.cmb` exists, move it into the per-book
+  // cache directory (or delete it as an orphan if the cache copy
+  // already exists). One-time per book; subsequent loads see no
+  // sibling and the check is a single Storage.exists call. Called
+  // from the top of Epub::load before any cache work runs.
+  void migrateLegacyCmbSidecar();
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir);
   ~Epub() = default;
-  // Sibling path: `foo.epub` -> `foo.cmb`. Returns empty when the
-  // input has no detectable extension. Public so other parts of the
-  // reader (e.g. Section::createSectionFile's CMB fast-path dispatch)
-  // can locate the sidecar without re-implementing the suffix swap.
-  static std::string deriveCmbPath(const std::string& epubPath);
+  // Path to the .cmb sidecar inside this book's cache directory. Lives
+  // alongside book.bin / cover.bmp / thumbs so users mounting their SD
+  // card never see a stray sidecar next to their epub files. Empty
+  // when cachePath is unset (should not happen post-construction).
+  std::string getCmbPath() const;
   static std::string cachePathForFilePath(const std::string& filepath, const std::string& cacheDir);
   std::string& getBasePath() { return contentBasePath; }
   bool load(bool buildIfMissing = true, bool skipLoadingCss = false);

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -134,6 +134,23 @@ class Epub {
   const std::string& getCoverItemHref() const;
   const std::string& getTextReferenceHref() const;
   const std::vector<std::string>& getCssFiles() const { return cssFiles; }
+  // CrumBLE #134: opportunistic .cmb writer. If no .cmb sidecar
+  // exists next to the EPUB, converts the currently-loaded book and
+  // writes one alongside the .epub. Subsequent opens (or post-
+  // cache-clear reopens) pick it up via the .cmb fast path in
+  // load(). Caller is expected to call this AFTER a successful
+  // load() -- the conversion path depends on bookMetadataCache
+  // being populated.
+  //
+  // Best-effort: returns true if a .cmb file exists (already there
+  // OR just written), false on any failure. On failure, partial
+  // output is removed so the next call retries cleanly.
+  //
+  // Synchronous and can take several seconds on big books (one
+  // expat pass per chapter). Called automatically at the end of
+  // load() so the next open hits the fast path; reader / utility
+  // code can call it explicitly if they want to force a refresh.
+  bool ensureCmbExists();
   // CrumBLE: true if the item is STORED (uncompressed) in the EPUB zip. A STORED
   // chapter needs no 32 KB DEFLATE window to cold-load, so the reader can build
   // it in place while BLE is connected instead of dropping/re-enabling BLE

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -101,7 +101,8 @@ bool BookMetadataCache::endWrite() {
   return true;
 }
 
-bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMetadata& metadata) {
+bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMetadata& metadata,
+                                     const std::deque<uint32_t>* precomputedCumulativeSizes) {
   // Open all three files, writing to meta, reading from spine and toc
   if (!Storage.openFileForWrite("BMC", cachePath + bookBinFile, bookFile)) {
     return false;
@@ -172,15 +173,27 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     }
   }
 
+  // CrumBLE #134: when the caller already knows cumulative sizes
+  // (i.e. they were stored in a .cmb sidecar), skip opening the EPUB
+  // ZIP entirely. Saves the ~30 KB central-dir walk for big books.
+  const bool usePrecomputed = (precomputedCumulativeSizes != nullptr &&
+                               static_cast<int>(precomputedCumulativeSizes->size()) == spineCount);
+  if (precomputedCumulativeSizes != nullptr && !usePrecomputed) {
+    LOG_ERR("BMC", "precomputedCumulativeSizes wrong size (%zu vs %d spine items); falling back to ZIP path",
+            precomputedCumulativeSizes->size(), spineCount);
+  }
+
   ZipFile zip(epubPath);
-  // Pre-open zip file to speed up size calculations
-  if (!zip.open()) {
-    LOG_ERR("BMC", "Could not open EPUB zip for size calculations");
-    // Explicit close() required: member variables persist beyond function scope
-    bookFile.close();
-    spineFile.close();
-    tocFile.close();
-    return false;
+  if (!usePrecomputed) {
+    // Pre-open zip file to speed up size calculations
+    if (!zip.open()) {
+      LOG_ERR("BMC", "Could not open EPUB zip for size calculations");
+      // Explicit close() required: member variables persist beyond function scope
+      bookFile.close();
+      spineFile.close();
+      tocFile.close();
+      return false;
+    }
   }
   // NOTE: We intentionally skip calling loadAllFileStatSlims() here.
   // For large EPUBs (2000+ chapters), pre-loading all ZIP central directory entries
@@ -193,7 +206,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   std::deque<uint32_t> spineSizes;
   bool useBatchSizes = false;
 
-  if (spineCount >= LARGE_SPINE_THRESHOLD) {
+  if (!usePrecomputed && spineCount >= LARGE_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
 
     std::deque<ZipFile::SizeTarget> targets;
@@ -242,40 +255,46 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     }
     lastSpineTocIndex = spineEntry.tocIndex;
 
-    size_t itemSize = 0;
-    if (useBatchSizes) {
-      itemSize = spineSizes[i];
-      if (itemSize == 0) {
+    if (usePrecomputed) {
+      // Use the cumulative size the caller already knows. No per-item
+      // additions; the .cmb stored values are already running totals.
+      cumSize = (*precomputedCumulativeSizes)[i];
+    } else {
+      size_t itemSize = 0;
+      if (useBatchSizes) {
+        itemSize = spineSizes[i];
+        if (itemSize == 0) {
+          const std::string path = FsHelpers::normalisePath(spineEntry.href);
+          if (!zip.getInflatedFileSize(path.c_str(), &itemSize)) {
+            LOG_ERR("BMC", "Warning: Could not get size for spine item: %s", path.c_str());
+          }
+        }
+      } else {
         const std::string path = FsHelpers::normalisePath(spineEntry.href);
         if (!zip.getInflatedFileSize(path.c_str(), &itemSize)) {
           LOG_ERR("BMC", "Warning: Could not get size for spine item: %s", path.c_str());
         }
       }
-    } else {
-      const std::string path = FsHelpers::normalisePath(spineEntry.href);
-      if (!zip.getInflatedFileSize(path.c_str(), &itemSize)) {
-        LOG_ERR("BMC", "Warning: Could not get size for spine item: %s", path.c_str());
+
+      constexpr size_t maxStoredCumulativeSize = std::numeric_limits<uint32_t>::max();
+      if (itemSize > maxStoredCumulativeSize || cumSize > maxStoredCumulativeSize - itemSize) {
+        LOG_ERR("BMC", "Spine cumulative size overflow for item %d (cumSize=%u, itemSize=%zu)", i, cumSize, itemSize);
+        zip.close();
+        bookFile.close();
+        spineFile.close();
+        tocFile.close();
+        return false;
       }
-    }
 
-    constexpr size_t maxStoredCumulativeSize = std::numeric_limits<uint32_t>::max();
-    if (itemSize > maxStoredCumulativeSize || cumSize > maxStoredCumulativeSize - itemSize) {
-      LOG_ERR("BMC", "Spine cumulative size overflow for item %d (cumSize=%u, itemSize=%zu)", i, cumSize, itemSize);
-      zip.close();
-      bookFile.close();
-      spineFile.close();
-      tocFile.close();
-      return false;
+      cumSize += itemSize;
     }
-
-    cumSize += itemSize;
     spineEntry.cumulativeSize = cumSize;
 
     // Write out spine data to book.bin
     writeSpineEntry(bookFile, spineEntry);
   }
-  // Close opened zip file
-  zip.close();
+  // Close opened zip file (no-op when usePrecomputed since we never opened it)
+  if (!usePrecomputed) zip.close();
 
   // Loop through toc entries from toc file writing to book.bin
   tocFile.seek(0);

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -99,8 +99,18 @@ class BookMetadataCache {
   bool endWrite();
   bool cleanupTmpFiles() const;
 
-  // Post-processing to update mappings and sizes
-  bool buildBookBin(const std::string& epubPath, const BookMetadata& metadata);
+  // Post-processing to update mappings and sizes.
+  // CrumBLE #134: optional `precomputedCumulativeSizes` lets callers
+  // pass in already-known cumulative inflated-size totals (one per
+  // spine entry) and skip opening the EPUB ZIP for size queries.
+  // When non-null, the vector MUST be `spineCount`-long; the function
+  // uses its entries verbatim (no per-item additions). When null
+  // (the default), behaviour matches the original: open the ZIP,
+  // query per-entry inflated sizes, accumulate. The .cmb fast path
+  // in Epub::load uses this to avoid the ~30 KB ZIP-central-dir walk
+  // on books that have a .cmb sidecar.
+  bool buildBookBin(const std::string& epubPath, const BookMetadata& metadata,
+                    const std::deque<uint32_t>* precomputedCumulativeSizes = nullptr);
 
   // Reading phase (read mode)
   bool load();

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -259,7 +259,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   // entirely. On any failure, fall through to the XHTML path so the chapter
   // still renders.
   {
-    const std::string cmbPath = Epub::deriveCmbPath(epub->getPath());
+    const std::string cmbPath = epub->getCmbPath();
     if (!cmbPath.empty() && Storage.exists(cmbPath.c_str())) {
       if (tryBuildSectionFromCmb(cmbPath, tmpSectionPath, fontId, lineCompression, extraParagraphSpacing,
                                  forceParagraphIndents, paragraphAlignment, viewportWidth, viewportHeight,

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -282,6 +282,15 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
         Storage.remove(tmpSectionPath.c_str());
       }
       pageCount = 0;
+      // Self-heal: if a .cmb is structurally OK enough to open but the
+      // builder consistently can't use it (stale format, partial write,
+      // future incompatibility), delete it so the next book open
+      // triggers a fresh conversion via ensureCmbExists. Without this
+      // the device gets stuck in a "broken .cmb forever falls back to
+      // XHTML" state with no way out short of clearing cache.
+      if (Storage.remove(cmbPath.c_str())) {
+        LOG_INF("SCT", "Removed unusable .cmb so next open rebuilds it: %s", cmbPath.c_str());
+      }
     }
   }
 

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -9,6 +9,7 @@
 #include "Epub/css/CssParser.h"
 #include "Page.h"
 #include "hyphenation/Hyphenator.h"
+#include "parsers/ChapterCmbSlimBuilder.h"
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
@@ -250,6 +251,31 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   {
     const auto sectionsDir = epub->getCachePath() + "/sections";
     Storage.mkdir(sectionsDir.c_str());
+  }
+
+  // CrumBLE: Slice 2 attempt A -- if the book has a .cmb sidecar, try to
+  // build the section cache from it directly. Skips the readItemContentsToStream
+  // call (and therefore the 32 KB inflate window), and skips the expat parse
+  // entirely. On any failure, fall through to the XHTML path so the chapter
+  // still renders.
+  {
+    const std::string cmbPath = Epub::deriveCmbPath(epub->getPath());
+    if (!cmbPath.empty() && Storage.exists(cmbPath.c_str())) {
+      if (tryBuildSectionFromCmb(cmbPath, tmpSectionPath, fontId, lineCompression, extraParagraphSpacing,
+                                 forceParagraphIndents, paragraphAlignment, viewportWidth, viewportHeight,
+                                 hyphenationEnabled, embeddedStyle, imageRendering, bionicReadingEnabled,
+                                 guideReadingEnabled, popupFn, buildStartMaxAlloc, imagesWereSuppressed,
+                                 layoutAbortedForLowMemory)) {
+        return true;
+      }
+      LOG_INF("SCT", ".cmb build failed for spine=%d, falling back to XHTML parser", spineIndex);
+      // tryBuildSectionFromCmb is responsible for cleaning up its own temp file
+      // on failure, but be defensive in case any path leaked the tmpSection.
+      if (Storage.exists(tmpSectionPath.c_str())) {
+        Storage.remove(tmpSectionPath.c_str());
+      }
+      pageCount = 0;
+    }
   }
 
   // Retry logic for SD card timing issues
@@ -679,4 +705,140 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
   }
 
   return resultPage;
+}
+
+bool Section::tryBuildSectionFromCmb(const std::string& cmbPath, const std::string& tmpSectionPath, const int fontId,
+                                     const float lineCompression, const bool extraParagraphSpacing,
+                                     const bool forceParagraphIndents, const uint8_t paragraphAlignment,
+                                     const uint16_t viewportWidth, const uint16_t viewportHeight,
+                                     const bool hyphenationEnabled, const bool embeddedStyle,
+                                     const uint8_t imageRendering, const bool bionicReadingEnabled,
+                                     const bool guideReadingEnabled, const std::function<void()>& popupFn,
+                                     const uint32_t buildStartMaxAlloc, bool* imagesWereSuppressed,
+                                     bool* layoutAbortedForLowMemory) {
+  if (Storage.exists(tmpSectionPath.c_str())) {
+    Storage.remove(tmpSectionPath.c_str());
+  }
+  if (!Storage.openFileForWrite("SCT", tmpSectionPath, file)) {
+    return false;
+  }
+  if (!writeSectionFileHeader(fontId, lineCompression, extraParagraphSpacing, forceParagraphIndents, paragraphAlignment,
+                              viewportWidth, viewportHeight, hyphenationEnabled, embeddedStyle, imageRendering,
+                              bionicReadingEnabled, guideReadingEnabled)) {
+    LOG_ERR("SCT", "Failed to write section header (CMB path)");
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+
+  std::vector<PageLutEntry> lut = {};
+
+  LOG_DBG("SCT", "CMB build start: spine=%d free=%u maxAlloc=%u", spineIndex, ESP.getFreeHeap(),
+          ESP.getMaxAllocHeap());
+
+  ChapterCmbSlimBuilder builder(
+      cmbPath, renderer, fontId, lineCompression, extraParagraphSpacing, forceParagraphIndents, paragraphAlignment,
+      viewportWidth, viewportHeight, hyphenationEnabled, bionicReadingEnabled, guideReadingEnabled, spineIndex,
+      [this, &lut](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex) {
+        lut.push_back({this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex});
+      },
+      popupFn);
+  Hyphenator::setPreferredLanguage(epub->getLanguage());
+  const bool success = builder.parseAndBuildPages();
+  LOG_DBG("SCT", "CMB build done: spine=%d success=%u pages=%u free=%u maxAlloc=%u", spineIndex, success, pageCount,
+          ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+
+  if (!success) {
+    LOG_ERR("SCT", "CMB build failed (spine=%d)", spineIndex);
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+
+  const bool builtImagesSuppressed = builder.wasLowMemoryFallbackTriggered();
+  if (imagesWereSuppressed) *imagesWereSuppressed = builtImagesSuppressed;
+  if (layoutAbortedForLowMemory) *layoutAbortedForLowMemory = builder.wasLowMemoryAbortTriggered();
+
+  // The remainder mirrors the XHTML path: LUT, anchor table, paragraph LUT,
+  // li LUT, then patch the header with finalized offsets and pageCount.
+  const uint32_t lutOffset = file.position();
+  bool hasFailedLutRecords = false;
+  for (const auto& entry : lut) {
+    if (entry.fileOffset == 0) {
+      hasFailedLutRecords = true;
+      break;
+    }
+    if (!serialization::tryWritePod(file, entry.fileOffset)) {
+      hasFailedLutRecords = true;
+      break;
+    }
+  }
+  if (hasFailedLutRecords) {
+    LOG_ERR("SCT", "CMB build: failed LUT writes");
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+
+  const uint32_t anchorMapOffset = file.position();
+  const auto& anchors = builder.getAnchors();
+  if (!serialization::tryWritePod(file, static_cast<uint16_t>(anchors.size()))) {
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+  for (const auto& [anchor, page] : anchors) {
+    if (!serialization::tryWriteString(file, anchor) || !serialization::tryWritePod(file, page)) {
+      file.close();
+      Storage.remove(tmpSectionPath.c_str());
+      return false;
+    }
+  }
+
+  const uint32_t paragraphLutOffset = file.position();
+  if (!serialization::tryWritePod(file, static_cast<uint16_t>(lut.size()))) {
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+  for (const auto& entry : lut) {
+    if (!serialization::tryWritePod(file, entry.paragraphIndex)) {
+      file.close();
+      Storage.remove(tmpSectionPath.c_str());
+      return false;
+    }
+  }
+
+  const uint32_t liLutFileOffset = static_cast<uint32_t>(file.position());
+  for (const auto& entry : lut) {
+    if (!serialization::tryWritePod(file, entry.listItemIndex)) {
+      file.close();
+      Storage.remove(tmpSectionPath.c_str());
+      return false;
+    }
+  }
+
+  if (!file.seek(HEADER_SIZE - sizeof(uint32_t) * 4 - sizeof(pageCount) - sizeof(uint32_t) - sizeof(bool)) ||
+      !serialization::tryWritePod(file, builtImagesSuppressed) ||
+      !serialization::tryWritePod(file, buildStartMaxAlloc) || !serialization::tryWritePod(file, pageCount) ||
+      !serialization::tryWritePod(file, lutOffset) || !serialization::tryWritePod(file, anchorMapOffset) ||
+      !serialization::tryWritePod(file, paragraphLutOffset) ||
+      !serialization::tryWritePod(file, liLutFileOffset) || !file.sync()) {
+    LOG_ERR("SCT", "Failed to finalize CMB section cache");
+    file.close();
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+  file.close();
+  if (Storage.exists(filePath.c_str())) {
+    Storage.remove(filePath.c_str());
+  }
+  if (!Storage.rename(tmpSectionPath.c_str(), filePath.c_str())) {
+    LOG_ERR("SCT", "Failed to promote CMB section cache into place");
+    Storage.remove(tmpSectionPath.c_str());
+    return false;
+  }
+  LOG_DBG("SCT", "Create section done (CMB): spine=%d pages=%u free=%u maxAlloc=%u", spineIndex, pageCount,
+          ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+  return true;
 }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -18,7 +18,14 @@ constexpr uint32_t SECTION_CACHE_MAGIC = 0x535843FF;  // bytes: 0xFF, "CXS"
 // with images dropped under low heap can be rebuilt with images once memory
 // recovers. The bump also invalidates any v37 cache that was silently cached
 // imageless (it will rebuild fresh on next open).
-constexpr uint8_t SECTION_FILE_VERSION = 38;
+// v39: invalidate every v38 cache so slice 2's CMB-first dispatch in
+// createSectionFile actually runs on the next book open. v38 caches were
+// built by the XHTML parser (with images, hr, footnotes, anchors); v39+
+// caches are produced either by ChapterCmbSlimBuilder (text-only first
+// cut) or by the XHTML fallback. Without this bump, existing v38 caches
+// silently mask the new path and we never see what slice 2 actually
+// renders.
+constexpr uint8_t SECTION_FILE_VERSION = 39;
 // How much the largest free block must have grown since a degraded build before
 // we bother rebuilding it for images (avoids rebuild churn on tiny variations).
 constexpr uint32_t SECTION_DEGRADED_REBUILD_MARGIN = 12 * 1024;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -20,6 +20,18 @@ class Section {
                               uint8_t paragraphAlignment, uint16_t viewportWidth, uint16_t viewportHeight,
                               bool hyphenationEnabled, bool embeddedStyle, uint8_t imageRendering,
                               bool bionicReadingEnabled, bool guideReadingEnabled);
+  // CrumBLE: Slice 2 attempt A -- builds the section cache directly from the
+  // pre-parsed .cmb sidecar instead of streaming + parsing the XHTML chapter.
+  // Returns true when the section cache was successfully built AND promoted
+  // into place (i.e. the caller can early-return). Returns false on any
+  // failure; the caller MUST fall back to the XHTML path.
+  bool tryBuildSectionFromCmb(const std::string& cmbPath, const std::string& tmpSectionPath, int fontId,
+                              float lineCompression, bool extraParagraphSpacing, bool forceParagraphIndents,
+                              uint8_t paragraphAlignment, uint16_t viewportWidth, uint16_t viewportHeight,
+                              bool hyphenationEnabled, bool embeddedStyle, uint8_t imageRendering,
+                              bool bionicReadingEnabled, bool guideReadingEnabled,
+                              const std::function<void()>& popupFn, uint32_t buildStartMaxAlloc,
+                              bool* imagesWereSuppressed, bool* layoutAbortedForLowMemory);
   uint32_t onPageComplete(std::unique_ptr<Page> page);
 
  public:

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
@@ -87,6 +87,11 @@ bool ChapterCmbSlimBuilder::parseAndBuildPages() {
   LOG_DBG("ECB", "Building chapter %d: paragraphs=%u free=%u maxAlloc=%u", chapterIdx, paragraphCount,
           ESP.getFreeHeap(), ESP.getMaxAllocHeap());
 
+  // Show the "Indexing..." popup up front, then tick it every 250 ms so
+  // it animates while the build runs. Mirrors ChapterHtmlSlimParser
+  // -- without the initial call the popup never appears, even when the
+  // chapter build takes long enough to be visible to the user.
+  if (popupFn) popupFn();
   uint32_t lastPopupTick = millis();
   constexpr uint32_t kPopupTickMs = 250;
 

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
@@ -1,0 +1,255 @@
+#include "ChapterCmbSlimBuilder.h"
+
+#include <Arduino.h>
+#include <CmbReader.h>
+#include <EpdFontFamily.h>
+#include <GfxRenderer.h>
+#include <Logging.h>
+
+#include <new>
+
+#include "Epub/Page.h"
+#include "Epub/css/CssStyle.h"
+
+namespace {
+// CMB style mask bits and EpdFontFamily::Style bits intentionally
+// overlap (BOLD=1, ITALIC=2, UNDERLINE=4, STRIKETHROUGH=8) so this is a
+// straight reinterpretation. Kept as a function so the assumption is
+// documented and stays grep-able.
+inline EpdFontFamily::Style mapCmbStyleToFontStyle(const uint8_t cmbStyle) {
+  return static_cast<EpdFontFamily::Style>(cmbStyle & 0x0F);
+}
+
+inline CssTextAlign mapCmbAlignment(const uint8_t cmbAlignment, const uint8_t userParagraphAlignment) {
+  if (cmbAlignment == cmb::kCmbAlignDefault) {
+    const auto user = static_cast<CssTextAlign>(userParagraphAlignment);
+    return (user == CssTextAlign::None) ? CssTextAlign::Justify : user;
+  }
+  switch (cmbAlignment) {
+    case cmb::kCmbAlignLeft:
+      return CssTextAlign::Left;
+    case cmb::kCmbAlignCenter:
+      return CssTextAlign::Center;
+    case cmb::kCmbAlignRight:
+      return CssTextAlign::Right;
+    case cmb::kCmbAlignJustify:
+    default:
+      return CssTextAlign::Justify;
+  }
+}
+
+inline bool isWordBreak(const char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+}  // namespace
+
+uint8_t ChapterCmbSlimBuilder::styleAtOffset(const uint16_t pos, const std::vector<cmb::CmbStyleRun>& runs) {
+  uint8_t mask = 0;
+  for (const auto& run : runs) {
+    if (pos >= run.start && pos < static_cast<uint32_t>(run.start) + run.length) {
+      mask |= run.style;
+    }
+  }
+  return mask;
+}
+
+BlockStyle ChapterCmbSlimBuilder::resolveBlockStyleForText(const uint8_t cmbAlignment,
+                                                           const uint8_t headingLevel) const {
+  BlockStyle style;
+  style.alignment = mapCmbAlignment(cmbAlignment, paragraphAlignment);
+  style.textAlignDefined = true;
+
+  // Headings get a half-line of breathing room above and below. The CSS
+  // path is doing more sophisticated work here (margin-collapsing, em-
+  // based padding); this is a coarse first approximation that keeps
+  // headings visually distinct in the slice-2 attempt-A pass.
+  if (headingLevel >= 1 && headingLevel <= 6) {
+    const auto lineHeight = static_cast<int16_t>(renderer.getLineHeight(fontId) * lineCompression + 0.5f);
+    style.marginTop = static_cast<int16_t>(lineHeight / 2);
+    style.marginBottom = static_cast<int16_t>(lineHeight / 2);
+  }
+  return style;
+}
+
+bool ChapterCmbSlimBuilder::parseAndBuildPages() {
+  cmb::CmbReader reader;
+  if (!reader.open(cmbPath.c_str())) {
+    LOG_DBG("ECB", "open failed: %s", cmbPath.c_str());
+    return false;
+  }
+
+  if (chapterIdx < 0 || chapterIdx >= reader.chapter_count()) {
+    LOG_DBG("ECB", "chapter idx %d out of range (count=%u)", chapterIdx, reader.chapter_count());
+    return false;
+  }
+
+  const uint16_t paragraphCount = reader.chapter_paragraph_count(static_cast<uint16_t>(chapterIdx));
+  LOG_DBG("ECB", "Building chapter %d: paragraphs=%u free=%u maxAlloc=%u", chapterIdx, paragraphCount,
+          ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+
+  uint32_t lastPopupTick = millis();
+  constexpr uint32_t kPopupTickMs = 250;
+
+  for (uint16_t i = 0; i < paragraphCount; ++i) {
+    if (popupFn && (millis() - lastPopupTick) >= kPopupTickMs) {
+      popupFn();
+      lastPopupTick = millis();
+    }
+
+    cmb::CmbParagraph paragraph;
+    if (!reader.load_paragraph(static_cast<uint16_t>(chapterIdx), i, paragraph)) {
+      LOG_ERR("ECB", "load_paragraph(%u,%u) failed", chapterIdx, i);
+      return false;
+    }
+
+    if (paragraph.type == cmb::kCmbBlockText) {
+      if (!processTextParagraph(paragraph.text, paragraph.runs, paragraph.alignment, paragraph.heading_level)) {
+        return false;
+      }
+    } else {
+      // kCmbBlockImage / kCmbBlockHr / kCmbBlockPageBreak: not handled
+      // in slice 2 attempt A. Silently skipped -- pages get smaller but
+      // textual content is intact. If the result looks wrong the caller
+      // falls back to the XHTML parser.
+    }
+
+    if (lowMemoryAbort) {
+      return false;
+    }
+    yield();
+  }
+
+  // Flush the final partially-filled page.
+  if (currentPage && !currentPage->elements.empty()) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset();
+  }
+
+  LOG_DBG("ECB", "Chapter %d built: pages=%d free=%u maxAlloc=%u", chapterIdx, completedPageCount, ESP.getFreeHeap(),
+          ESP.getMaxAllocHeap());
+  return true;
+}
+
+bool ChapterCmbSlimBuilder::processTextParagraph(const std::string& text,
+                                                 const std::vector<cmb::CmbStyleRun>& runs, const uint8_t alignment,
+                                                 const uint8_t headingLevel) {
+  // Empty paragraph: still consumes vertical space so emit a placeholder
+  // line via an empty ParsedText (matches HTML parser's <br>/empty-<p>
+  // handling).
+  const BlockStyle blockStyle = resolveBlockStyleForText(alignment, headingLevel);
+
+  ParsedText textBlock(extraParagraphSpacing, forceParagraphIndents, hyphenationEnabled, bionicReadingEnabled,
+                       guideReadingEnabled, blockStyle);
+
+  if (!text.empty()) {
+    const size_t n = text.size();
+    size_t i = 0;
+    bool attachNext = false;
+    while (i < n) {
+      // Skip leading whitespace runs (multiple consecutive spaces
+      // collapse to one word boundary).
+      while (i < n && isWordBreak(text[i])) {
+        ++i;
+        attachNext = false;  // whitespace always resets attach state
+      }
+      if (i >= n) break;
+
+      const size_t wordStart = i;
+      uint8_t currentStyle = styleAtOffset(static_cast<uint16_t>(wordStart), runs);
+      size_t segStart = wordStart;
+      bool firstSegmentOfWord = true;
+      while (i < n && !isWordBreak(text[i])) {
+        // Detect mid-word style transition by sampling at byte boundaries.
+        // Only sample at codepoint boundaries to avoid splitting a UTF-8
+        // multibyte sequence; continuation bytes (10xxxxxx) skip past.
+        const auto byte = static_cast<uint8_t>(text[i]);
+        const bool isContinuation = (byte & 0xC0) == 0x80;
+        if (!isContinuation && i > segStart) {
+          const uint8_t styleHere = styleAtOffset(static_cast<uint16_t>(i), runs);
+          if (styleHere != currentStyle) {
+            const std::string segment = text.substr(segStart, i - segStart);
+            const EpdFontFamily::Style fontStyle = mapCmbStyleToFontStyle(currentStyle);
+            const bool underline = (currentStyle & cmb::kCmbStyleUnderline) != 0;
+            const bool attach = firstSegmentOfWord ? attachNext : true;
+            textBlock.addWord(segment, fontStyle, underline, attach, false);
+            firstSegmentOfWord = false;
+            segStart = i;
+            currentStyle = styleHere;
+          }
+        }
+        ++i;
+      }
+      if (i > segStart) {
+        const std::string segment = text.substr(segStart, i - segStart);
+        const EpdFontFamily::Style fontStyle = mapCmbStyleToFontStyle(currentStyle);
+        const bool underline = (currentStyle & cmb::kCmbStyleUnderline) != 0;
+        const bool attach = firstSegmentOfWord ? attachNext : true;
+        textBlock.addWord(segment, fontStyle, underline, attach, false);
+      }
+      // After a whole whitespace-bounded token, the next token is a
+      // fresh word (no attach).
+      attachNext = false;
+    }
+  }
+
+  layoutAndEmit(textBlock);
+  return !lowMemoryAbort;
+}
+
+void ChapterCmbSlimBuilder::layoutAndEmit(ParsedText& textBlock) {
+  if (!currentPage) {
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      return;
+    }
+    currentPageNextY = 0;
+  }
+
+  const BlockStyle& blockStyle = textBlock.getBlockStyle();
+  const auto lineHeight = static_cast<int16_t>(renderer.getLineHeight(fontId) * lineCompression + 0.5f);
+
+  if (blockStyle.marginTop > 0) currentPageNextY += blockStyle.marginTop;
+  if (blockStyle.paddingTop > 0) currentPageNextY += blockStyle.paddingTop;
+
+  const int horizontalInset = blockStyle.totalHorizontalInset();
+  const uint16_t effectiveWidth =
+      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+
+  textBlock.layoutAndExtractLines(
+      renderer, fontId, effectiveWidth,
+      [this](const std::shared_ptr<TextBlock>& tb) { addLineToPage(tb); });
+
+  if (blockStyle.marginBottom > 0) currentPageNextY += blockStyle.marginBottom;
+  if (blockStyle.paddingBottom > 0) currentPageNextY += blockStyle.paddingBottom;
+  if (extraParagraphSpacing) currentPageNextY += lineHeight / 2;
+}
+
+void ChapterCmbSlimBuilder::addLineToPage(std::shared_ptr<TextBlock> line) {
+  const auto lineHeight = static_cast<int16_t>(renderer.getLineHeight(fontId) * lineCompression + 0.5f);
+
+  if (!currentPage) {
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      return;
+    }
+    currentPageNextY = 0;
+  }
+
+  if (currentPageNextY + lineHeight > viewportHeight) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      return;
+    }
+    currentPageNextY = 0;
+  }
+
+  const int16_t xOffset = line->getBlockStyle().leftInset();
+  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  currentPageNextY = static_cast<int16_t>(currentPageNextY + lineHeight);
+}

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
@@ -1,0 +1,128 @@
+#pragma once
+
+// ChapterCmbSlimBuilder -- Slice 2 attempt A. Walks pre-parsed paragraphs
+// out of the .cmb sidecar (CmbReader) and feeds them through the existing
+// ParsedText layout core, exactly the way ChapterHtmlSlimParser does for
+// HTML chapters. The point is to skip the expat parse + CSS resolve +
+// table/footnote machinery on a cold open when we have the .cmb already.
+//
+// Scope intentionally narrow:
+//   - kCmbBlockText paragraphs only (text, alignment, heading_level,
+//     style runs). Bionic, guide dots, hyphenation pass-through.
+//   - kCmbBlockImage / kCmbBlockHr / kCmbBlockPageBreak are SKIPPED in
+//     this first cut (no images, no <hr>). Adding them is a follow-up.
+//   - No anchor-table, no footnote-table; both default to empty
+//     vectors so Section.cpp's existing writers serialise zero entries.
+//
+// If parseAndBuildPages returns false the caller must clear its lut +
+// pageCount and fall back to ChapterHtmlSlimParser. Section.cpp does
+// exactly that.
+
+#include <CmbFormat.h>
+
+#include <climits>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Epub/ParsedText.h"
+#include "Epub/blocks/BlockStyle.h"
+#include "Epub/blocks/TextBlock.h"
+
+class Page;
+class GfxRenderer;
+
+class ChapterCmbSlimBuilder {
+ public:
+  using PageCompleteFn = std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)>;
+
+  ChapterCmbSlimBuilder(const std::string& cmbPath, GfxRenderer& renderer, int fontId, float lineCompression,
+                        bool extraParagraphSpacing, bool forceParagraphIndents, uint8_t paragraphAlignment,
+                        uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
+                        bool bionicReadingEnabled, bool guideReadingEnabled, int chapterIdx,
+                        PageCompleteFn completePageFn, const std::function<void()>& popupFn = nullptr)
+      : cmbPath(cmbPath),
+        renderer(renderer),
+        completePageFn(std::move(completePageFn)),
+        popupFn(popupFn),
+        fontId(fontId),
+        lineCompression(lineCompression),
+        extraParagraphSpacing(extraParagraphSpacing),
+        forceParagraphIndents(forceParagraphIndents),
+        paragraphAlignment(paragraphAlignment),
+        viewportWidth(viewportWidth),
+        viewportHeight(viewportHeight),
+        hyphenationEnabled(hyphenationEnabled),
+        bionicReadingEnabled(bionicReadingEnabled),
+        guideReadingEnabled(guideReadingEnabled),
+        chapterIdx(chapterIdx) {}
+
+  ~ChapterCmbSlimBuilder() = default;
+
+  // Returns true when the chapter rendered to completion. Returns false
+  // on open failure / read failure / out-of-memory; in that case the
+  // caller MUST discard whatever pages it accumulated and rebuild via
+  // the XHTML parser path.
+  bool parseAndBuildPages();
+
+  // Empty placeholders for Section.cpp parity. Anchors/footnotes aren't
+  // yet wired through .cmb -- the returned vectors stay empty so
+  // Section.cpp writes the same zero-entry tables it would for an
+  // anchor-less HTML chapter.
+  const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
+  bool wasLowMemoryFallbackTriggered() const { return false; }
+  bool wasLowMemoryAbortTriggered() const { return lowMemoryAbort; }
+
+ private:
+  const std::string& cmbPath;
+  GfxRenderer& renderer;
+  PageCompleteFn completePageFn;
+  std::function<void()> popupFn;
+  int fontId;
+  float lineCompression;
+  bool extraParagraphSpacing;
+  bool forceParagraphIndents;
+  uint8_t paragraphAlignment;  // user-setting cast to CssTextAlign on use
+  uint16_t viewportWidth;
+  uint16_t viewportHeight;
+  bool hyphenationEnabled;
+  bool bionicReadingEnabled;
+  bool guideReadingEnabled;
+  int chapterIdx;
+
+  std::unique_ptr<Page> currentPage;
+  int16_t currentPageNextY = 0;
+  int completedPageCount = 0;
+  bool lowMemoryAbort = false;
+
+  // Mirrors ChapterHtmlSlimParser fields for compatibility with the
+  // page-complete callback signature.
+  uint16_t xpathParagraphIndex = 0;
+  uint16_t xpathListItemIndex = 0;
+
+  // Stays empty -- see getAnchors() doc above.
+  std::vector<std::pair<std::string, uint16_t>> anchorData;
+
+  // Resolve CMB alignment + user setting into the BlockStyle alignment to
+  // hand to ParsedText. kCmbAlignDefault means "use the user setting".
+  BlockStyle resolveBlockStyleForText(uint8_t cmbAlignment, uint8_t headingLevel) const;
+
+  // Emit one CMB text paragraph. Returns false on OOM.
+  bool processTextParagraph(const std::string& text, const std::vector<cmb::CmbStyleRun>& runs, uint8_t alignment,
+                            uint8_t headingLevel);
+
+  // Run layout on the supplied ParsedText and append the resulting
+  // lines to currentPage; flushes pages when they overflow.
+  void layoutAndEmit(ParsedText& textBlock);
+
+  // Append one rendered line to the current page. Flushes the page
+  // when the next line would overflow viewportHeight.
+  void addLineToPage(std::shared_ptr<TextBlock> line);
+
+  // Look up the style mask at byte offset `pos` by linear-scanning runs.
+  // CMB run table size is tiny (almost always < 16 entries per
+  // paragraph) so linear is fine.
+  static uint8_t styleAtOffset(uint16_t pos, const std::vector<cmb::CmbStyleRun>& runs);
+};

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -307,6 +307,14 @@ bool ZipFile::getCompressionMethod(const char* filename, uint16_t* method) {
   return true;
 }
 
+bool ZipFile::getLocalHeaderOffset(const char* filename, uint32_t* offset) {
+  if (filename == nullptr || offset == nullptr) return false;
+  FileStatSlim fileStat = {};
+  if (!loadFileStatSlim(filename, &fileStat)) return false;
+  *offset = fileStat.localHeaderOffset;
+  return true;
+}
+
 int ZipFile::fillUncompressedSizes(std::deque<SizeTarget>& targets, std::deque<uint32_t>& sizes) {
   if (targets.empty()) {
     return 0;

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -65,6 +65,13 @@ class ZipFile {
   // The reader uses this to tell whether a chapter can cold-load without the
   // 32 KB inflate window (STORED) and therefore build in place under BLE.
   bool getCompressionMethod(const char* filename, uint16_t* method);
+  // CrumBLE #134: report a file's local-file-header offset in the
+  // ZIP. .cmb stores these to let the reader pull image bytes from
+  // the EPUB ZIP at display time without walking the central
+  // directory (~30 bytes per image read vs ~60 bytes per central-dir
+  // entry x N entries). Wraps the internal cached central-dir
+  // lookup; no behavioural change for existing callers.
+  bool getLocalHeaderOffset(const char* filename, uint32_t* offset);
   // Batch lookup: scan ZIP central dir once and fill sizes for matching targets.
   // targets must be sorted by (hash, len). sizes[target.index] receives uncompressedSize.
   // Returns number of targets matched.

--- a/test/cmb_roundtrip/CmbRoundtripTest.cpp
+++ b/test/cmb_roundtrip/CmbRoundtripTest.cpp
@@ -92,6 +92,12 @@ void test_text_paragraphs(const char* path) {
         {"OEBPS/c2.xhtml", 5000},
     };
     md.css_files = {"OEBPS/styles.css", "OEBPS/print.css"};
+    md.toc = {
+        {"Cover", "OEBPS/c0.xhtml", "", 1},
+        {"Chapter One", "OEBPS/c1.xhtml", "", 1},
+        {"Section 1.1", "OEBPS/c1.xhtml", "sec1-1", 2},
+        {"Chapter Two", "OEBPS/c2.xhtml", "", 1},
+    };
     CMB_EXPECT(w.finish(md));
   }
 
@@ -117,6 +123,16 @@ void test_text_paragraphs(const char* path) {
   CMB_EXPECT_EQ(md_out.css_files.size(), static_cast<size_t>(2));
   CMB_EXPECT_EQ(md_out.css_files[0], std::string("OEBPS/styles.css"));
   CMB_EXPECT_EQ(md_out.css_files[1], std::string("OEBPS/print.css"));
+  // v4 toc round-trip.
+  CMB_EXPECT_EQ(md_out.toc.size(), static_cast<size_t>(4));
+  CMB_EXPECT_EQ(md_out.toc[0].title, std::string("Cover"));
+  CMB_EXPECT_EQ(md_out.toc[0].href, std::string("OEBPS/c0.xhtml"));
+  CMB_EXPECT_EQ(md_out.toc[0].anchor, std::string(""));
+  CMB_EXPECT_EQ(static_cast<int>(md_out.toc[0].level), 1);
+  CMB_EXPECT_EQ(md_out.toc[2].title, std::string("Section 1.1"));
+  CMB_EXPECT_EQ(md_out.toc[2].href, std::string("OEBPS/c1.xhtml"));
+  CMB_EXPECT_EQ(md_out.toc[2].anchor, std::string("sec1-1"));
+  CMB_EXPECT_EQ(static_cast<int>(md_out.toc[2].level), 2);
 
   uint32_t expected_total = 0;
   for (size_t ci = 0; ci < chapters.size(); ++ci) {

--- a/test/cmb_roundtrip/CmbRoundtripTest.cpp
+++ b/test/cmb_roundtrip/CmbRoundtripTest.cpp
@@ -190,6 +190,96 @@ void test_image_refs_and_blocks(const char* path) {
   CMB_EXPECT_EQ(p.image_key, 1u);
 }
 
+void test_styled_paragraphs(const char* path) {
+  std::cout << "[test] styled paragraphs (runs + heading + alignment + anchor)\n";
+  {
+    cmb::CmbWriter w;
+    CMB_EXPECT(w.open(path));
+
+    w.begin_chapter();
+
+    // Paragraph 1: a heading with an anchor id and centered alignment.
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockText;
+      p.text = "Chapter One";
+      p.heading_level = 1;
+      p.alignment = cmb::kCmbAlignCenter;
+      p.anchor_id = "ch1";
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+
+    // Paragraph 2: body text with mixed bold + italic runs and a
+    // trailing left-aligned setting.
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockText;
+      p.text = "The quick brown fox jumps over the lazy dog.";
+      p.alignment = cmb::kCmbAlignLeft;
+      // "quick" (offset 4, length 5) -- bold
+      p.runs.push_back({4, 5, cmb::kCmbStyleBold});
+      // "brown fox" (offset 10, length 9) -- italic
+      p.runs.push_back({10, 9, cmb::kCmbStyleItalic});
+      // "lazy" (offset 35, length 4) -- bold + italic + underline
+      p.runs.push_back({35, 4, static_cast<uint8_t>(cmb::kCmbStyleBold | cmb::kCmbStyleItalic | cmb::kCmbStyleUnderline)});
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+
+    // Paragraph 3: image block with an anchor id.
+    const uint16_t img_key = w.add_image_ref(0x4000, 100, 150);
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockImage;
+      p.image_key = img_key;
+      p.anchor_id = "cover";
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+
+    w.end_chapter();
+    CMB_EXPECT(w.finish("Styled", "Tester"));
+  }
+
+  cmb::CmbReader r;
+  CMB_EXPECT(r.open(path));
+  CMB_EXPECT_EQ(r.chapter_count(), 1u);
+  CMB_EXPECT_EQ(r.chapter_paragraph_count(0), 3u);
+
+  cmb::CmbParagraph p;
+  // Paragraph 1 -- heading.
+  CMB_EXPECT(r.load_paragraph(0, 0, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockText));
+  CMB_EXPECT_EQ(p.text, std::string("Chapter One"));
+  CMB_EXPECT_EQ(static_cast<int>(p.heading_level), 1);
+  CMB_EXPECT_EQ(static_cast<int>(p.alignment), static_cast<int>(cmb::kCmbAlignCenter));
+  CMB_EXPECT_EQ(p.anchor_id, std::string("ch1"));
+  CMB_EXPECT_EQ(p.runs.size(), 0u);
+
+  // Paragraph 2 -- styled body.
+  CMB_EXPECT(r.load_paragraph(0, 1, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockText));
+  CMB_EXPECT_EQ(p.text, std::string("The quick brown fox jumps over the lazy dog."));
+  CMB_EXPECT_EQ(static_cast<int>(p.heading_level), 0);
+  CMB_EXPECT_EQ(static_cast<int>(p.alignment), static_cast<int>(cmb::kCmbAlignLeft));
+  CMB_EXPECT_EQ(p.anchor_id, std::string(""));
+  CMB_EXPECT_EQ(p.runs.size(), 3u);
+  CMB_EXPECT_EQ(p.runs[0].start, 4u);
+  CMB_EXPECT_EQ(p.runs[0].length, 5u);
+  CMB_EXPECT_EQ(static_cast<int>(p.runs[0].style), static_cast<int>(cmb::kCmbStyleBold));
+  CMB_EXPECT_EQ(p.runs[1].start, 10u);
+  CMB_EXPECT_EQ(p.runs[1].length, 9u);
+  CMB_EXPECT_EQ(static_cast<int>(p.runs[1].style), static_cast<int>(cmb::kCmbStyleItalic));
+  CMB_EXPECT_EQ(p.runs[2].start, 35u);
+  CMB_EXPECT_EQ(p.runs[2].length, 4u);
+  CMB_EXPECT_EQ(static_cast<int>(p.runs[2].style),
+                static_cast<int>(cmb::kCmbStyleBold | cmb::kCmbStyleItalic | cmb::kCmbStyleUnderline));
+
+  // Paragraph 3 -- image with anchor.
+  CMB_EXPECT(r.load_paragraph(0, 2, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockImage));
+  CMB_EXPECT_EQ(p.image_key, 0u);
+  CMB_EXPECT_EQ(p.anchor_id, std::string("cover"));
+}
+
 void test_magic_rejection(const char* path) {
   std::cout << "[test] reader rejects non-cmb files\n";
   // Write a file that starts with the wrong magic.
@@ -218,6 +308,7 @@ int main(int argc, char** argv) {
   test_empty_book(tmp_path);
   test_text_paragraphs(tmp_path);
   test_image_refs_and_blocks(tmp_path);
+  test_styled_paragraphs(tmp_path);
   test_magic_rejection(tmp_path);
 
   std::remove(tmp_path);

--- a/test/cmb_roundtrip/CmbRoundtripTest.cpp
+++ b/test/cmb_roundtrip/CmbRoundtripTest.cpp
@@ -1,0 +1,231 @@
+// Host-side round-trip test for the .cmb format library (CmbWriter +
+// CmbReader). Synthesises a small in-memory book, writes to a temp
+// file, reads it back, and verifies every accessible field matches.
+//
+// Builds without the rest of the firmware -- no ESP-IDF, no
+// EpubReaderActivity, no Epub class. Just the format library +
+// stdlib. Run via test/run_cmb_roundtrip_test.sh.
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "Cmb/CmbFormat.h"
+#include "Cmb/CmbReader.h"
+#include "Cmb/CmbWriter.h"
+
+namespace {
+
+int g_failures = 0;
+
+#define CMB_EXPECT(cond)                                                                                              \
+  do {                                                                                                                \
+    if (!(cond)) {                                                                                                    \
+      std::cerr << "FAIL [" << __FILE__ << ":" << __LINE__ << "] " << #cond << "\n";                                  \
+      ++g_failures;                                                                                                   \
+    }                                                                                                                 \
+  } while (0)
+
+#define CMB_EXPECT_EQ(a, b)                                                                                           \
+  do {                                                                                                                \
+    auto _av = (a);                                                                                                   \
+    auto _bv = (b);                                                                                                   \
+    if (!(_av == _bv)) {                                                                                              \
+      std::cerr << "FAIL [" << __FILE__ << ":" << __LINE__ << "] " << #a << " (=" << _av << ") != " << #b             \
+                << " (=" << _bv << ")\n";                                                                             \
+      ++g_failures;                                                                                                   \
+    }                                                                                                                 \
+  } while (0)
+
+void test_empty_book(const char* path) {
+  std::cout << "[test] empty book (0 chapters)\n";
+  {
+    cmb::CmbWriter w;
+    CMB_EXPECT(w.open(path));
+    CMB_EXPECT(w.finish("Title", "Author"));
+  }
+  cmb::CmbReader r;
+  CMB_EXPECT(r.open(path));
+  CMB_EXPECT_EQ(r.chapter_count(), 0u);
+  CMB_EXPECT_EQ(r.image_count(), 0u);
+  CMB_EXPECT_EQ(r.paragraph_count(), 0u);
+  CMB_EXPECT_EQ(r.metadata_title(), std::string("Title"));
+  CMB_EXPECT_EQ(r.metadata_author(), std::string("Author"));
+}
+
+void test_text_paragraphs(const char* path) {
+  std::cout << "[test] 3 chapters, varied text\n";
+  // Fixture: each chapter has a different number of paragraphs to
+  // stress the per-chapter descriptor table.
+  const std::vector<std::vector<std::string>> chapters = {
+      {"First paragraph of chapter zero.", "Second paragraph."},
+      {"Only paragraph in chapter one."},
+      {"Three", "paragraphs", "in chapter two with longer text content."},
+  };
+
+  {
+    cmb::CmbWriter w;
+    CMB_EXPECT(w.open(path));
+    for (const auto& chapter : chapters) {
+      w.begin_chapter();
+      for (const auto& p_text : chapter) {
+        cmb::CmbParagraph p;
+        p.type = cmb::kCmbBlockText;
+        p.text = p_text;
+        CMB_EXPECT(w.write_paragraph(p));
+      }
+      w.end_chapter();
+    }
+    CMB_EXPECT(w.finish("Round Trip", "Test Author"));
+  }
+
+  cmb::CmbReader r;
+  CMB_EXPECT(r.open(path));
+  CMB_EXPECT_EQ(r.chapter_count(), static_cast<uint16_t>(chapters.size()));
+
+  uint32_t expected_total = 0;
+  for (size_t ci = 0; ci < chapters.size(); ++ci) {
+    expected_total += static_cast<uint32_t>(chapters[ci].size());
+    CMB_EXPECT_EQ(r.chapter_paragraph_count(static_cast<uint16_t>(ci)),
+                  static_cast<uint16_t>(chapters[ci].size()));
+
+    // char_count should be sum of UTF-8 byte lengths of every text
+    // paragraph in the chapter.
+    uint32_t expected_chars = 0;
+    for (const auto& p_text : chapters[ci]) expected_chars += static_cast<uint32_t>(p_text.size());
+    CMB_EXPECT_EQ(r.chapter_char_count(static_cast<uint16_t>(ci)), expected_chars);
+
+    // Load each paragraph back and verify text content.
+    for (size_t pi = 0; pi < chapters[ci].size(); ++pi) {
+      cmb::CmbParagraph out;
+      CMB_EXPECT(r.load_paragraph(static_cast<uint16_t>(ci), static_cast<uint16_t>(pi), out));
+      CMB_EXPECT_EQ(out.type, static_cast<uint8_t>(cmb::kCmbBlockText));
+      CMB_EXPECT_EQ(out.text, chapters[ci][pi]);
+    }
+  }
+  CMB_EXPECT_EQ(r.paragraph_count(), expected_total);
+}
+
+void test_image_refs_and_blocks(const char* path) {
+  std::cout << "[test] image refs + image blocks + hr + page break\n";
+  {
+    cmb::CmbWriter w;
+    CMB_EXPECT(w.open(path));
+    // Pre-register two images. Third add of the same (offset,w,h)
+    // tuple should dedupe to the same key.
+    const uint16_t k0 = w.add_image_ref(0x1000, 100, 150);
+    const uint16_t k1 = w.add_image_ref(0x2000, 200, 320);
+    const uint16_t k0_again = w.add_image_ref(0x1000, 100, 150);
+    CMB_EXPECT_EQ(k0, 0u);
+    CMB_EXPECT_EQ(k1, 1u);
+    CMB_EXPECT_EQ(k0_again, 0u);  // dedup
+
+    w.begin_chapter();
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockText;
+      p.text = "Text before image";
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockImage;
+      p.image_key = k0;
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockHr;
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockPageBreak;
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+    {
+      cmb::CmbParagraph p;
+      p.type = cmb::kCmbBlockImage;
+      p.image_key = k1;
+      CMB_EXPECT(w.write_paragraph(p));
+    }
+    w.end_chapter();
+    CMB_EXPECT(w.finish("Mixed Blocks", "Author"));
+  }
+
+  cmb::CmbReader r;
+  CMB_EXPECT(r.open(path));
+  CMB_EXPECT_EQ(r.chapter_count(), 1u);
+  CMB_EXPECT_EQ(r.image_count(), 2u);
+  CMB_EXPECT_EQ(r.chapter_paragraph_count(0), 5u);
+
+  cmb::CmbImageRef img;
+  CMB_EXPECT(r.image_ref(0, img));
+  CMB_EXPECT_EQ(img.local_header_offset, 0x1000u);
+  CMB_EXPECT_EQ(img.width, 100u);
+  CMB_EXPECT_EQ(img.height, 150u);
+  CMB_EXPECT(r.image_ref(1, img));
+  CMB_EXPECT_EQ(img.local_header_offset, 0x2000u);
+  CMB_EXPECT_EQ(img.width, 200u);
+  CMB_EXPECT_EQ(img.height, 320u);
+
+  cmb::CmbParagraph p;
+  CMB_EXPECT(r.load_paragraph(0, 0, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockText));
+  CMB_EXPECT_EQ(p.text, std::string("Text before image"));
+
+  CMB_EXPECT(r.load_paragraph(0, 1, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockImage));
+  CMB_EXPECT_EQ(p.image_key, 0u);
+
+  CMB_EXPECT(r.load_paragraph(0, 2, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockHr));
+
+  CMB_EXPECT(r.load_paragraph(0, 3, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockPageBreak));
+
+  CMB_EXPECT(r.load_paragraph(0, 4, p));
+  CMB_EXPECT_EQ(p.type, static_cast<uint8_t>(cmb::kCmbBlockImage));
+  CMB_EXPECT_EQ(p.image_key, 1u);
+}
+
+void test_magic_rejection(const char* path) {
+  std::cout << "[test] reader rejects non-cmb files\n";
+  // Write a file that starts with the wrong magic.
+  FILE* f = std::fopen(path, "wb");
+  if (f == nullptr) {
+    std::cerr << "could not open " << path << " for fixture write\n";
+    ++g_failures;
+    return;
+  }
+  const char garbage[] = "NOTCMB1.....................";
+  std::fwrite(garbage, 1, sizeof(garbage), f);
+  std::fclose(f);
+
+  cmb::CmbReader r;
+  // open() should return false (magic mismatch). is_open() should be
+  // false afterward.
+  CMB_EXPECT(!r.open(path));
+  CMB_EXPECT(!r.is_open());
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  const char* tmp_path = (argc > 1) ? argv[1] : "/tmp/cmb_roundtrip_test.bin";
+
+  test_empty_book(tmp_path);
+  test_text_paragraphs(tmp_path);
+  test_image_refs_and_blocks(tmp_path);
+  test_magic_rejection(tmp_path);
+
+  std::remove(tmp_path);
+
+  if (g_failures == 0) {
+    std::cout << "ALL TESTS PASSED\n";
+    return 0;
+  }
+  std::cerr << g_failures << " FAILURE(S)\n";
+  return 1;
+}

--- a/test/cmb_roundtrip/CmbRoundtripTest.cpp
+++ b/test/cmb_roundtrip/CmbRoundtripTest.cpp
@@ -43,7 +43,7 @@ void test_empty_book(const char* path) {
   {
     cmb::CmbWriter w;
     CMB_EXPECT(w.open(path));
-    CMB_EXPECT(w.finish("Title", "Author"));
+    CMB_EXPECT(w.finish("Title", "Author", {}));
   }
   cmb::CmbReader r;
   CMB_EXPECT(r.open(path));
@@ -77,12 +77,19 @@ void test_text_paragraphs(const char* path) {
       }
       w.end_chapter();
     }
-    CMB_EXPECT(w.finish("Round Trip", "Test Author"));
+    const std::vector<std::string> spine = {"OEBPS/c0.xhtml", "OEBPS/c1.xhtml", "OEBPS/c2.xhtml"};
+    CMB_EXPECT(w.finish("Round Trip", "Test Author", spine));
   }
 
   cmb::CmbReader r;
   CMB_EXPECT(r.open(path));
   CMB_EXPECT_EQ(r.chapter_count(), static_cast<uint16_t>(chapters.size()));
+
+  // v2 spine file round-trip.
+  CMB_EXPECT_EQ(r.spine_files().size(), static_cast<size_t>(3));
+  CMB_EXPECT_EQ(r.spine_files()[0], std::string("OEBPS/c0.xhtml"));
+  CMB_EXPECT_EQ(r.spine_files()[1], std::string("OEBPS/c1.xhtml"));
+  CMB_EXPECT_EQ(r.spine_files()[2], std::string("OEBPS/c2.xhtml"));
 
   uint32_t expected_total = 0;
   for (size_t ci = 0; ci < chapters.size(); ++ci) {
@@ -151,7 +158,7 @@ void test_image_refs_and_blocks(const char* path) {
       CMB_EXPECT(w.write_paragraph(p));
     }
     w.end_chapter();
-    CMB_EXPECT(w.finish("Mixed Blocks", "Author"));
+    CMB_EXPECT(w.finish("Mixed Blocks", "Author", {"OEBPS/single.xhtml"}));
   }
 
   cmb::CmbReader r;
@@ -236,7 +243,7 @@ void test_styled_paragraphs(const char* path) {
     }
 
     w.end_chapter();
-    CMB_EXPECT(w.finish("Styled", "Tester"));
+    CMB_EXPECT(w.finish("Styled", "Tester", {"OEBPS/ch.xhtml"}));
   }
 
   cmb::CmbReader r;

--- a/test/cmb_roundtrip/CmbRoundtripTest.cpp
+++ b/test/cmb_roundtrip/CmbRoundtripTest.cpp
@@ -43,7 +43,10 @@ void test_empty_book(const char* path) {
   {
     cmb::CmbWriter w;
     CMB_EXPECT(w.open(path));
-    CMB_EXPECT(w.finish("Title", "Author", {}));
+    cmb::CmbBookMetadata md;
+    md.title = "Title";
+    md.author = "Author";
+    CMB_EXPECT(w.finish(md));
   }
   cmb::CmbReader r;
   CMB_EXPECT(r.open(path));
@@ -77,19 +80,43 @@ void test_text_paragraphs(const char* path) {
       }
       w.end_chapter();
     }
-    const std::vector<std::string> spine = {"OEBPS/c0.xhtml", "OEBPS/c1.xhtml", "OEBPS/c2.xhtml"};
-    CMB_EXPECT(w.finish("Round Trip", "Test Author", spine));
+    cmb::CmbBookMetadata md;
+    md.title = "Round Trip";
+    md.author = "Test Author";
+    md.language = "en-US";
+    md.cover_href = "OEBPS/cover.jpg";
+    md.text_reference_href = "OEBPS/c0.xhtml";
+    md.spine = {
+        {"OEBPS/c0.xhtml", 1000},
+        {"OEBPS/c1.xhtml", 2500},
+        {"OEBPS/c2.xhtml", 5000},
+    };
+    md.css_files = {"OEBPS/styles.css", "OEBPS/print.css"};
+    CMB_EXPECT(w.finish(md));
   }
 
   cmb::CmbReader r;
   CMB_EXPECT(r.open(path));
   CMB_EXPECT_EQ(r.chapter_count(), static_cast<uint16_t>(chapters.size()));
 
-  // v2 spine file round-trip.
-  CMB_EXPECT_EQ(r.spine_files().size(), static_cast<size_t>(3));
-  CMB_EXPECT_EQ(r.spine_files()[0], std::string("OEBPS/c0.xhtml"));
-  CMB_EXPECT_EQ(r.spine_files()[1], std::string("OEBPS/c1.xhtml"));
-  CMB_EXPECT_EQ(r.spine_files()[2], std::string("OEBPS/c2.xhtml"));
+  // v3 metadata round-trip: title/author/language/cover/text-ref +
+  // spine entries (href + cumulative_size) + css files list.
+  const auto& md_out = r.metadata();
+  CMB_EXPECT_EQ(md_out.title, std::string("Round Trip"));
+  CMB_EXPECT_EQ(md_out.author, std::string("Test Author"));
+  CMB_EXPECT_EQ(md_out.language, std::string("en-US"));
+  CMB_EXPECT_EQ(md_out.cover_href, std::string("OEBPS/cover.jpg"));
+  CMB_EXPECT_EQ(md_out.text_reference_href, std::string("OEBPS/c0.xhtml"));
+  CMB_EXPECT_EQ(md_out.spine.size(), static_cast<size_t>(3));
+  CMB_EXPECT_EQ(md_out.spine[0].href, std::string("OEBPS/c0.xhtml"));
+  CMB_EXPECT_EQ(md_out.spine[0].cumulative_size, 1000u);
+  CMB_EXPECT_EQ(md_out.spine[1].href, std::string("OEBPS/c1.xhtml"));
+  CMB_EXPECT_EQ(md_out.spine[1].cumulative_size, 2500u);
+  CMB_EXPECT_EQ(md_out.spine[2].href, std::string("OEBPS/c2.xhtml"));
+  CMB_EXPECT_EQ(md_out.spine[2].cumulative_size, 5000u);
+  CMB_EXPECT_EQ(md_out.css_files.size(), static_cast<size_t>(2));
+  CMB_EXPECT_EQ(md_out.css_files[0], std::string("OEBPS/styles.css"));
+  CMB_EXPECT_EQ(md_out.css_files[1], std::string("OEBPS/print.css"));
 
   uint32_t expected_total = 0;
   for (size_t ci = 0; ci < chapters.size(); ++ci) {
@@ -158,7 +185,11 @@ void test_image_refs_and_blocks(const char* path) {
       CMB_EXPECT(w.write_paragraph(p));
     }
     w.end_chapter();
-    CMB_EXPECT(w.finish("Mixed Blocks", "Author", {"OEBPS/single.xhtml"}));
+    cmb::CmbBookMetadata md;
+    md.title = "Mixed Blocks";
+    md.author = "Author";
+    md.spine = {{"OEBPS/single.xhtml", 800}};
+    CMB_EXPECT(w.finish(md));
   }
 
   cmb::CmbReader r;
@@ -243,7 +274,11 @@ void test_styled_paragraphs(const char* path) {
     }
 
     w.end_chapter();
-    CMB_EXPECT(w.finish("Styled", "Tester", {"OEBPS/ch.xhtml"}));
+    cmb::CmbBookMetadata md;
+    md.title = "Styled";
+    md.author = "Tester";
+    md.spine = {{"OEBPS/ch.xhtml", 1200}};
+    CMB_EXPECT(w.finish(md));
   }
 
   cmb::CmbReader r;

--- a/test/run_cmb_roundtrip_test.sh
+++ b/test/run_cmb_roundtrip_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Host-side build + run of the .cmb format library round-trip test.
+# No ESP-IDF, no platformio.  Just g++/clang on the format library
+# sources plus the test driver.  Exercises CmbWriter -> CmbReader
+# end-to-end on a temp file.
+#
+# Usage:
+#   test/run_cmb_roundtrip_test.sh
+#
+# Exit status mirrors the test binary (0 on PASS).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/cmb_roundtrip"
+BINARY="$BUILD_DIR/CmbRoundtripTest"
+
+mkdir -p "$BUILD_DIR"
+
+SOURCES=(
+  "$ROOT_DIR/test/cmb_roundtrip/CmbRoundtripTest.cpp"
+  "$ROOT_DIR/lib/Cmb/CmbWriter.cpp"
+  "$ROOT_DIR/lib/Cmb/CmbReader.cpp"
+)
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+)
+
+CXX="${CXX:-g++}"
+
+echo "[build] $CXX ${CXXFLAGS[*]} ..."
+"$CXX" "${CXXFLAGS[@]}" "${SOURCES[@]}" -o "$BINARY"
+
+echo "[run]   $BINARY"
+"$BINARY"


### PR DESCRIPTION
## Summary

Adds a CrumBLE-owned single-file pre-parsed sidecar format (.cmb, \"CrumBLE Book\") that lives next to each EPUB and short-circuits two expensive cold-path steps:

1. **`Epub::load` fast path** -- when the .cmb exists, the spine/TOC/cover/CSS-list/language/cumulative-sizes metadata is populated from the sidecar instead of opening the ZIP, walking the central directory, querying inflated sizes for every spine item, and parsing content.opf + the TOC. Big books skip ~30 KB of cold-open heap churn.

2. **`Section::createSectionFile` fast path** (slice 2 attempt A) -- when the .cmb exists, chapter pages are built directly from the pre-parsed paragraphs (text, alignment, heading level, inline style runs) instead of streaming the chapter XHTML out of the ZIP and running it through the expat + CSS + table/footnote pipeline. Skips the 32 KB DEFLATE inflate window per chapter open.

Format design lives in `lib/Cmb/CmbFormat.h`. Inspired by microreader's `.mrb` layout patterns (chapter table in RAM, per-paragraph descriptor on SD, image refs as ZIP local-header offsets) but the format is ours -- magic \`CMB1\`, our versioning, no shared code.

The .cmb is written opportunistically on first successful book open (`Epub::ensureCmbExists`). It's a cache -- safe to delete, will be re-generated on next open.

## Commits (read in order)

1. **define .cmb on-disk format** -- header/chapter/image/paragraph layouts + LE serialization
2. **CmbWriter + CmbReader skeleton** -- buffered file IO + load helpers
3. **EPUB->CMB converter + host-side round-trip test** -- expat-driven paragraph walker
4. **style runs + heading + anchor id + expat-driven converter**
5. **converter emits image refs + \<hr\> blocks**
6. **format v2 -- spine hrefs in metadata blob**
7. **format v3 -- full BookMetadataCache field set** (cumulative sizes, language, cover, text-ref, CSS list)
8. **format v4 -- TOC entries**
9. **wire Epub::load .cmb fast path** -- cold-open heap win lands
10. **auto-write .cmb sidecar on book open**
11. **slice 2 attempt A -- build sections from .cmb paragraphs** (Section.cpp dispatch + ChapterCmbSlimBuilder)

## Scope of slice 2 attempt A

Intentionally narrow -- if this regresses anything, only this commit reverts:

- \`kCmbBlockText\` paragraphs only (text, alignment, heading level, bold/italic/underline/strikethrough style runs)
- \`kCmbBlockImage\` / \`kCmbBlockHr\` / \`kCmbBlockPageBreak\` silently skipped for now
- No anchors / footnotes / CSS-derived block style
- On any failure (open / read / OOM) falls through to the existing \`ChapterHtmlSlimParser\` so chapters still render

## Test plan

- [x] Build: \`pio run -e tiny\` clean (Flash 82.4%, RAM 32.6%)
- [x] Host-side round-trip tests pass (\`test/cmb_roundtrip/\`)
- [x] Device read: image book, text book, book with image on chapter, crossing chapter boundary, BT connection
- [ ] Watch for: image rendering on chapters that have inline images (slice 2 skips them; the chapter still renders text but the image won't appear until image-block wiring lands as a follow-up)
- [ ] Watch for: \<hr\> rendering on chapters that use horizontal rules (same -- skipped in slice 2)
- [ ] Test on a footnote-heavy book to confirm the XHTML fallback is fine; footnotes via .cmb come later

## Known follow-ups (not in this PR)

- Wire \`kCmbBlockImage\` through ChapterCmbSlimBuilder (images stop rendering on CMB path; XHTML path still has them)
- Wire \`kCmbBlockHr\`
- Anchor / fragment-id table for in-book link navigation through CMB
- Format v5: pre-baked cover BMPs (separate task)

## Notes

- Out-of-the-box: existing books without a .cmb work unchanged. First open writes the sidecar; second open uses it.
- The sidecar is keyed by file path; nothing in the EPUB or its mtime is hashed. If an EPUB is replaced in place with the same filename and a different content, the .cmb will be stale -- delete it manually or implement an mtime check (deferred).