### PR TITLE
fix(home): cover-load reliability + placeholder cap + partial-row nav

### DIFF
--- a/src/CoverThumbStatus.cpp
+++ b/src/CoverThumbStatus.cpp
@@ -12,24 +12,26 @@ namespace {
 // firmware has ever seen is /.crosspoint/<format>_<hash>; the marker
 // is a sibling of stats.bin / thumb_*.bmp inside that dir.
 constexpr char kCacheDir[] = "/.crosspoint";
-// CrumBLE #133 follow-up: suffix bumped to _v2 so markers written by
-// earlier builds (which set them on transient heap-OOM failures during
-// 16-book sequential gens at 4x4 / 220x320 at 2x2) get silently
-// ignored. The old .marker files leak as zero-byte files on SD --
-// acceptable; isMarkedFailed only checks the new path. Books that
-// genuinely lack a cover get re-marked under _v2 on first attempt
-// with this build, then stop retrying as the marker system intends.
-constexpr char kMarkerSuffix[] = "/thumb_failed_v2.marker";
+// CrumBLE: suffix is _v3 -- bumped from _v2 so markers written by
+// pre-per-size builds get silently ignored (the global-per-book v2
+// markers permanently poisoned books whose covers had only failed at a
+// single transient-OOM size). The {width}x{height} portion is filled
+// in per call site so the marker for Collections@130x190 doesn't block
+// regeneration at Carousel@296x468. Old _v2 .marker files leak as
+// zero-byte files on SD -- acceptable; isMarkedFailed only checks the
+// new size-scoped path.
+constexpr char kMarkerPrefix[] = "/thumb_failed_v3_";
+constexpr char kMarkerSuffix[] = ".marker";
 
-std::string markerPathForBook(const std::string& bookPath) {
+std::string bookCacheDir(const std::string& bookPath) {
   if (FsHelpers::hasEpubExtension(bookPath)) {
-    return Epub::cachePathForFilePath(bookPath, kCacheDir) + kMarkerSuffix;
+    return Epub::cachePathForFilePath(bookPath, kCacheDir);
   }
   if (FsHelpers::hasXtcExtension(bookPath)) {
     // Mirrors Xtc(filepath, cacheDir) constructor's path derivation. Kept
     // inline rather than adding Xtc::cachePathForFilePath() to avoid
     // touching the Xtc class for a single call site.
-    return std::string(kCacheDir) + "/xtc_" + std::to_string(std::hash<std::string>{}(bookPath)) + kMarkerSuffix;
+    return std::string(kCacheDir) + "/xtc_" + std::to_string(std::hash<std::string>{}(bookPath));
   }
   // TXT / Markdown have no cover thumbnail concept; the markers system
   // never applies to them. Return empty so exists() short-circuits to
@@ -37,33 +39,39 @@ std::string markerPathForBook(const std::string& bookPath) {
   return "";
 }
 
+std::string markerPathForBook(const std::string& bookPath, int width, int height) {
+  if (width <= 0 || height <= 0) return "";
+  const std::string dir = bookCacheDir(bookPath);
+  if (dir.empty()) return "";
+  return dir + kMarkerPrefix + std::to_string(width) + "x" + std::to_string(height) + kMarkerSuffix;
+}
+
 }  // namespace
 
 namespace CoverThumbStatus {
 
-bool isMarkedFailed(const std::string& bookPath) {
-  const std::string marker = markerPathForBook(bookPath);
+bool isMarkedFailed(const std::string& bookPath, int width, int height) {
+  const std::string marker = markerPathForBook(bookPath, width, height);
   if (marker.empty()) return false;
   return Storage.exists(marker.c_str());
 }
 
-void markFailed(const std::string& bookPath) {
-  const std::string marker = markerPathForBook(bookPath);
+void markFailed(const std::string& bookPath, int width, int height) {
+  const std::string marker = markerPathForBook(bookPath, width, height);
   if (marker.empty()) return;
   // Make sure the cache dir exists -- a failure that triggers BEFORE any
   // successful cache write would otherwise leave the marker un-creatable.
-  // Truncate the suffix to get the parent dir.
-  const std::string parent = marker.substr(0, marker.size() - sizeof(kMarkerSuffix) + 1);
-  Storage.mkdir(parent.c_str());
+  const std::string parent = bookCacheDir(bookPath);
+  if (!parent.empty()) Storage.mkdir(parent.c_str());
   if (!Storage.writeFile(marker.c_str(), String(""))) {
-    LOG_ERR("CTS", "Failed to write thumb-failed marker for %s", bookPath.c_str());
+    LOG_ERR("CTS", "Failed to write thumb-failed marker for %s (%dx%d)", bookPath.c_str(), width, height);
     return;
   }
-  LOG_INF("CTS", "Marked thumb generation failed for %s", bookPath.c_str());
+  LOG_INF("CTS", "Marked thumb generation failed for %s (%dx%d)", bookPath.c_str(), width, height);
 }
 
-void clearFailed(const std::string& bookPath) {
-  const std::string marker = markerPathForBook(bookPath);
+void clearFailed(const std::string& bookPath, int width, int height) {
+  const std::string marker = markerPathForBook(bookPath, width, height);
   if (marker.empty()) return;
   if (!Storage.exists(marker.c_str())) return;
   Storage.remove(marker.c_str());

--- a/src/CoverThumbStatus.h
+++ b/src/CoverThumbStatus.h
@@ -2,33 +2,44 @@
 #include <string>
 
 // CrumBLE: persistent "do not retry" marker for cover-thumbnail generation
-// that has failed on a given book. Some EPUBs ship a cover image we can't
-// decode on-device (PNG with palette quirks, malformed JPEGs, OPF that
-// points at a missing path, etc.). Without this gate, every visit to the
-// home carousel or a collection grid re-attempts generation, briefly
-// flashes a Loading popup, fails again, and finally renders the
-// placeholder — turning what should be a snappy scroll into a stutter.
+// that has failed on a given book at a given W x H. Some EPUBs ship a
+// cover image we can't decode on-device (PNG with palette quirks,
+// malformed JPEGs, OPF that points at a missing path, etc.). Without
+// this gate, every visit to the home carousel or a collection grid
+// re-attempts generation, briefly flashes a Loading popup, fails again,
+// and finally renders the placeholder -- turning what should be a
+// snappy scroll into a stutter.
 //
-// The marker is a zero-byte file at <book cachePath>/thumb_failed.marker
-// so it persists across reboots (lives on SD card alongside the book's
-// other cache state). It's cleared whenever a generation attempt
-// succeeds (e.g. a future build improves decode, or the user replaces
-// the book file with a fixed copy and we walk the new cachePath).
+// The marker is a zero-byte file at
+// <book cachePath>/thumb_failed_v3_<W>x<H>.marker so it persists across
+// reboots (lives on SD card alongside the book's other cache state).
+// It's cleared whenever a generation attempt for the SAME size succeeds.
+//
+// Per-size scoping (v3) fixes the case where a transient memory-pressure
+// failure at one size (e.g. Collections at 100x150) would otherwise
+// permanently block that book's cover from being regenerated -- even
+// though another size (e.g. Carousel at 296x468) had already cached a
+// usable thumb. Previously markers were global per book, which meant
+// one bad attempt poisoned every future attempt regardless of size.
 namespace CoverThumbStatus {
 
 // True when we've previously failed to generate a cover thumbnail for
-// the book at `bookPath`. Call before any generateThumbBmp*() to skip
-// the doomed-to-fail attempt and fall through to the placeholder render.
-bool isMarkedFailed(const std::string& bookPath);
+// the book at `bookPath` at the requested size. Call before any
+// generateThumbBmp*() to skip the doomed-to-fail attempt and fall
+// through to the placeholder render. Size MUST match the W,H that the
+// caller plans to request (otherwise markers are silently ignored,
+// which is the conservative behaviour for a UI cache hint).
+bool isMarkedFailed(const std::string& bookPath, int width, int height);
 
-// Persist the "give up" marker so future visits stop retrying. Call
-// after a generateThumbBmp*() returns false.
-void markFailed(const std::string& bookPath);
+// Persist the "give up" marker so future visits stop retrying at this
+// size. Call after a generateThumbBmp*() returns false for the same W,H.
+void markFailed(const std::string& bookPath, int width, int height);
 
 // Drop the marker (idempotent). Call after a successful regeneration in
 // case the book had been previously marked but is now decodable (build
 // improvement, or user replaced the file). Cheap no-op when the marker
-// doesn't exist.
-void clearFailed(const std::string& bookPath);
+// doesn't exist. Size-scoped to the same W,H the caller just succeeded
+// at; pass the same dimensions that were used in the gen attempt.
+void clearFailed(const std::string& bookPath, int width, int height);
 
 }  // namespace CoverThumbStatus

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -612,7 +612,8 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     // been cleared at the time of failure (recent.json persisted "")
     // but, defense in depth: also short-circuit here so a re-derivation
     // anywhere upstream can't reanimate the retry loop.
-    if (CoverThumbStatus::isMarkedFailed(book.path)) {
+    if (CoverThumbStatus::isMarkedFailed(book.path, LyraCarouselTheme::kCenterThumbW,
+                                         LyraCarouselTheme::kCenterThumbH)) {
       progress++;
       continue;
     }
@@ -659,10 +660,20 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                       ESP.getFreeHeap(), ESP.getMaxAllocHeap());
               updateRecentBookCoverPath(book, "");
               book.coverBmpPath = "";
-              CoverThumbStatus::markFailed(book.path);
+              if (centerMissing)
+                CoverThumbStatus::markFailed(book.path, LyraCarouselTheme::kCenterThumbW,
+                                             LyraCarouselTheme::kCenterThumbH);
+              if (sideMissing)
+                CoverThumbStatus::markFailed(book.path, LyraCarouselTheme::kSideCoverW,
+                                             LyraCarouselTheme::kSideCoverH);
             } else {
               bookUpdated[bookIdx] = true;
-              CoverThumbStatus::clearFailed(book.path);
+              if (centerMissing)
+                CoverThumbStatus::clearFailed(book.path, LyraCarouselTheme::kCenterThumbW,
+                                              LyraCarouselTheme::kCenterThumbH);
+              if (sideMissing)
+                CoverThumbStatus::clearFailed(book.path, LyraCarouselTheme::kSideCoverW,
+                                              LyraCarouselTheme::kSideCoverH);
             }
             coverRendered = false;
             requestUpdate();
@@ -684,10 +695,20 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               if (!success) {
                 updateRecentBookCoverPath(book, "");
                 book.coverBmpPath = "";
-                CoverThumbStatus::markFailed(book.path);
+                if (centerMissing)
+                  CoverThumbStatus::markFailed(book.path, LyraCarouselTheme::kCenterThumbW,
+                                               LyraCarouselTheme::kCenterThumbH);
+                if (sideMissing)
+                  CoverThumbStatus::markFailed(book.path, LyraCarouselTheme::kSideCoverW,
+                                               LyraCarouselTheme::kSideCoverH);
               } else {
                 bookUpdated[bookIdx] = true;
-                CoverThumbStatus::clearFailed(book.path);
+                if (centerMissing)
+                  CoverThumbStatus::clearFailed(book.path, LyraCarouselTheme::kCenterThumbW,
+                                                LyraCarouselTheme::kCenterThumbH);
+                if (sideMissing)
+                  CoverThumbStatus::clearFailed(book.path, LyraCarouselTheme::kSideCoverW,
+                                                LyraCarouselTheme::kSideCoverH);
               }
               coverRendered = false;
               requestUpdate();
@@ -708,6 +729,13 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
             }
             GUI.fillPopupProgress(renderer, popupRect, 10 + progress * progressIncrement);
+            // W,H the gen attempt below will resolve to -- mirrored here so the
+            // per-size CoverThumbStatus marker matches the dims of the actual
+            // generateThumbBmp*() call (otherwise the marker is silently ignored).
+            const int thumbW = useMinimalThumb
+                                   ? minimalHomeCoverWidth(coverHeight)
+                                   : static_cast<int>((static_cast<int64_t>(coverHeight) * 3 + 2) / 5);
+            const int thumbH = useMinimalThumb ? minimalHomeCoverHeight(coverHeight) : coverHeight;
             bool success;
             if (useMinimalThumb) {
               // Minimal uses an ADAPTIVE thumbnail (contain unusual ratios),
@@ -722,7 +750,7 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                 // a Loading popup + a second of SD I/O per visit. If a
                 // future build improves cache load, the user can clear
                 // /.crosspoint/<hash>/thumb_failed.marker manually.
-                CoverThumbStatus::markFailed(book.path);
+                CoverThumbStatus::markFailed(book.path, thumbW, thumbH);
                 coverRendered = false;
                 requestUpdate();
                 progress++;
@@ -742,10 +770,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                       ESP.getFreeHeap(), ESP.getMaxAllocHeap());
               updateRecentBookCoverPath(book, "");
               book.coverBmpPath = "";
-              CoverThumbStatus::markFailed(book.path);
+              CoverThumbStatus::markFailed(book.path, thumbW, thumbH);
             } else {
               bookUpdated[bookIdx] = true;  // non-carousel path reuses same tracking
-              CoverThumbStatus::clearFailed(book.path);
+              CoverThumbStatus::clearFailed(book.path, thumbW, thumbH);
             }
             coverRendered = false;
             requestUpdate();
@@ -757,6 +785,11 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
                 popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
               }
               GUI.fillPopupProgress(renderer, popupRect, 10 + progress * progressIncrement);
+              // Mirror the W,H the gen attempt resolves to: Xtc::generateThumbBmp(h)
+              // derives width as static_cast<uint16_t>(h * 0.6).
+              const int thumbW = useMinimalThumb ? minimalHomeCoverWidth(coverHeight)
+                                                 : static_cast<int>(static_cast<uint16_t>(coverHeight * 0.6));
+              const int thumbH = useMinimalThumb ? minimalHomeCoverHeight(coverHeight) : coverHeight;
               const bool success =
                   useMinimalThumb ? xtc.generateThumbBmp(static_cast<uint16_t>(minimalHomeCoverWidth(coverHeight)),
                                                          static_cast<uint16_t>(minimalHomeCoverHeight(coverHeight)))
@@ -764,10 +797,10 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
               if (!success) {
                 updateRecentBookCoverPath(book, "");
                 book.coverBmpPath = "";
-                CoverThumbStatus::markFailed(book.path);
+                CoverThumbStatus::markFailed(book.path, thumbW, thumbH);
               } else {
                 bookUpdated[bookIdx] = true;
-                CoverThumbStatus::clearFailed(book.path);
+                CoverThumbStatus::clearFailed(book.path, thumbW, thumbH);
               }
               coverRendered = false;
               requestUpdate();
@@ -857,10 +890,16 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
   // via CoverThumbStatus so we don't retry forever on undecodable
   // covers.
   if (!isMinimal) {
+    // Mirrors UITheme::getCoverThumbPath(coverBmpPath, coverHeight) and
+    // Epub::generateThumbBmpNoIndex(0, coverHeight) -- both derive W from H
+    // via (H*3+2)/5. For XTC we resolve the marker per-call below since
+    // generateThumbBmp(h) derives W via static_cast<uint16_t>(h*0.6) and
+    // can round to a different value at certain heights.
+    const int statsThumbWEpub = static_cast<int>((static_cast<int64_t>(coverHeight) * 3 + 2) / 5);
     const auto& allRecents = RECENT_BOOKS.getBooks();
     for (const RecentBook& sb : allRecents) {
       if (sb.coverBmpPath.empty()) continue;
-      if (CoverThumbStatus::isMarkedFailed(sb.path)) continue;
+      if (CoverThumbStatus::isMarkedFailed(sb.path, statsThumbWEpub, coverHeight)) continue;
       const std::string thumbPath = UITheme::getCoverThumbPath(sb.coverBmpPath, coverHeight);
       if (thumbPath.empty() || Storage.exists(thumbPath.c_str())) continue;
       if (!Storage.exists(sb.path.c_str())) continue;  // book deleted from SD
@@ -875,18 +914,20 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
         popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
       }
       bool success = false;
+      int attemptedW = statsThumbWEpub;
       if (FsHelpers::hasEpubExtension(sb.path)) {
         Epub epub(sb.path, "/.crosspoint");
         success = epub.generateThumbBmpNoIndex(0, coverHeight);
       } else if (FsHelpers::hasXtcExtension(sb.path)) {
         Xtc xtc(sb.path, "/.crosspoint");
+        attemptedW = static_cast<int>(static_cast<uint16_t>(coverHeight * 0.6));
         if (xtc.load()) {
           success = xtc.generateThumbBmp(coverHeight);
         }
       }
       if (!success) {
         LOG_DBG("HOME", "Stats cover gen failed: %s (free=%u)", sb.path.c_str(), ESP.getFreeHeap());
-        CoverThumbStatus::markFailed(sb.path);
+        CoverThumbStatus::markFailed(sb.path, attemptedW, coverHeight);
       }
     }
   }
@@ -1038,7 +1079,7 @@ void HomeActivity::loadShelfCovers(int cellWidth, int cellHeight, int scrollOffs
     // home visit to allow a single transient-failure retry). If gen has
     // been marked permanently failed for this book, render the
     // placeholder and don't even pay the existence-check below.
-    if (CoverThumbStatus::isMarkedFailed(bookPath)) {
+    if (CoverThumbStatus::isMarkedFailed(bookPath, cellWidth, cellHeight)) {
       processed++;
       continue;
     }
@@ -1129,13 +1170,13 @@ void HomeActivity::loadShelfCovers(int cellWidth, int cellHeight, int scrollOffs
       failedShelfCovers.push_back(bookPath);
       // Persist across boots so the next session's home doesn't repeat
       // the same Loading-popup flash for this book.
-      CoverThumbStatus::markFailed(bookPath);
+      CoverThumbStatus::markFailed(bookPath, cellWidth, cellHeight);
       LOG_ERR("HOME", "shelf: thumb generation failed for %s; rendering blank (won't retry)",
               bookPath.c_str());
     } else if (genSucceeded) {
       // Wipe the persistent marker on the rare cross-build "fixed cover"
       // case (decoder improved or user replaced the book file).
-      CoverThumbStatus::clearFailed(bookPath);
+      CoverThumbStatus::clearFailed(bookPath, cellWidth, cellHeight);
     }
     // Count this generation attempt toward the first-index cap (only enforced
     // while wasFreshFirstBoot(); harmless to increment otherwise).

--- a/src/activities/home/RecentBooksGridActivity.cpp
+++ b/src/activities/home/RecentBooksGridActivity.cpp
@@ -148,6 +148,20 @@ int moveVerticalInGrid(const int currentIndex, const int totalItems, const int c
       if (nextRowCandidate < totalItems && (nextRowCandidate / safeItemsPerPage) == currentPage) {
         return nextRowCandidate;
       }
+      // Partial last row on this page (e.g. 3 books in a 2x2, or 5 books in
+      // a 3x3, or 6 books in a 4x4): the same-column slot doesn't exist
+      // in the next row, but some cells DO. Snap to the rightmost
+      // available cell of that partial row so pressing DOWN feels like a
+      // real move instead of a no-op or a jarring jump to the next page.
+      const int currentPageStart = currentPage * safeItemsPerPage;
+      const int currentPageEnd = std::min(currentPageStart + safeItemsPerPage, totalItems);
+      const int nextRowStartOnPage = currentPageStart + (currentRow + 1) * columns;
+      if (nextRowStartOnPage < currentPageEnd) {
+        // currentPageEnd-1 is the last cell of the partial row (since the
+        // row above DOES have currentColumn filled, partial truncation
+        // necessarily lands within this row).
+        return currentPageEnd - 1;
+      }
     }
 
     const int nextPage = (currentPage + 1) % totalPages;

--- a/src/activities/home/RecentBooksGridActivity.cpp
+++ b/src/activities/home/RecentBooksGridActivity.cpp
@@ -234,12 +234,12 @@ std::string getReusableCoverPath(const RecentBook& book) {
   return book.coverBmpPath;
 }
 
-void ensureReusableCoverPath(RecentBook& book) {
+void ensureReusableCoverPath(RecentBook& book, int coverWidth, int coverHeight) {
   // Books whose thumb-gen has previously failed should stay on the
   // placeholder path. Without this gate, the re-derivation below would
   // refill coverBmpPath with the template, which trips needsCoverThumbGeneration
   // -> Loading popup -> repeat failure on every shelf revisit.
-  if (CoverThumbStatus::isMarkedFailed(book.path)) {
+  if (CoverThumbStatus::isMarkedFailed(book.path, coverWidth, coverHeight)) {
     if (!book.coverBmpPath.empty()) {
       book.coverBmpPath = "";
       updateRecentBookCoverPath(book, "");
@@ -289,7 +289,7 @@ void RecentBooksGridActivity::loadRecentBooks() {
       // previous generation has been marked permanently-failed so we don't
       // re-derive a path that will only trigger a doomed retry below
       // (loading popup + same failure every revisit).
-      if (!CoverThumbStatus::isMarkedFailed(path)) {
+      if (!CoverThumbStatus::isMarkedFailed(path, coverWidth_, coverHeight_)) {
         if (FsHelpers::hasEpubExtension(path)) {
           book.coverBmpPath = Epub(path, "/.crosspoint").getThumbBmpPath();
         } else if (FsHelpers::hasXtcExtension(path)) {
@@ -393,10 +393,10 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
   bool needsGeneration = false;
   for (int i = pageStart; i < pageEnd; ++i) {
     RecentBook& book = recentBooks[i].book;
-    ensureReusableCoverPath(book);
+    ensureReusableCoverPath(book, coverWidth_, coverHeight_);
     // Books with a "thumb generation failed" marker render the placeholder
     // (coverBmpPath stays empty) and never trigger the Loading popup.
-    if (CoverThumbStatus::isMarkedFailed(book.path)) continue;
+    if (CoverThumbStatus::isMarkedFailed(book.path, coverWidth_, coverHeight_)) continue;
     if (book.coverBmpPath.empty()) {
       needsGeneration = true;
       break;
@@ -420,7 +420,7 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
   for (int i = pageStart; i < pageEnd; ++i) {
     RecentBook& book = recentBooks[i].book;
     // Already-known-failed books: render placeholder, no Loading popup.
-    if (CoverThumbStatus::isMarkedFailed(book.path)) {
+    if (CoverThumbStatus::isMarkedFailed(book.path, coverWidth_, coverHeight_)) {
       processedCount++;
       continue;
     }
@@ -455,7 +455,7 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
           const std::string reusablePath = epub.getThumbBmpPath();
           book.coverBmpPath = reusablePath;
           updateRecentBookCoverPath(book, reusablePath);
-          CoverThumbStatus::clearFailed(book.path);
+          CoverThumbStatus::clearFailed(book.path, coverWidth_, coverHeight_);
         } else {
           // CrumBLE #133 follow-up: re-enabled markFailed after BOTH
           // gen paths fail (NoIndex AND heavy). Earlier this branch
@@ -469,7 +469,7 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
           // for the same books on every Bookshelf entry.
           book.coverBmpPath = "";
           updateRecentBookCoverPath(book, "");
-          CoverThumbStatus::markFailed(book.path);
+          CoverThumbStatus::markFailed(book.path, coverWidth_, coverHeight_);
         }
       } else if (FsHelpers::hasXtcExtension(book.path)) {
         Xtc xtc(book.path, "/.crosspoint");
@@ -486,11 +486,11 @@ void RecentBooksGridActivity::loadPageCovers(int pageStart) {
             const std::string reusablePath = xtc.getThumbBmpPath();
             book.coverBmpPath = reusablePath;
             updateRecentBookCoverPath(book, reusablePath);
-            CoverThumbStatus::clearFailed(book.path);
+            CoverThumbStatus::clearFailed(book.path, coverWidth_, coverHeight_);
           } else {
             book.coverBmpPath = "";
             updateRecentBookCoverPath(book, "");
-            CoverThumbStatus::markFailed(book.path);
+            CoverThumbStatus::markFailed(book.path, coverWidth_, coverHeight_);
           }
         }
       }

--- a/src/components/themes/lyra/LyraFlowTheme.cpp
+++ b/src/components/themes/lyra/LyraFlowTheme.cpp
@@ -839,11 +839,14 @@ void LyraFlowTheme::drawBookshelfStrip(GfxRenderer& renderer, Rect rect, const c
               : nullptr;
       if (cellTitle != nullptr) {
         constexpr int kPlaceholderPadX = 4;
-        // CrumBLE: cap chosen to comfortably fit any real-world title at
-        // SMALL font (~10 px line height) within the 150 px cell. cap is
-        // generous so we never truncate; wrappedText returns only as
-        // many lines as the text actually needs.
-        constexpr int kPlaceholderMaxLines = 10;
+        // Cap title wrapping so a long boxed-set title (e.g. "George R. R.
+        // Martin's A Game of Thrones 5-Book Boxed Set") doesn't fill the
+        // entire placeholder cell with wrapped text. 4 lines matches the
+        // MinimalTheme placeholder convention and leaves visual room for
+        // the cell to read as "missing cover, here's a hint of the title"
+        // rather than a wall of small bold text. wrappedText auto-
+        // ellipsizes on the last line when the title overflows the cap.
+        constexpr int kPlaceholderMaxLines = 4;
         const auto titleLines = renderer.wrappedText(SMALL_FONT_ID, cellTitle->c_str(),
                                                       kCellWidth - 2 * kPlaceholderPadX, kPlaceholderMaxLines,
                                                       EpdFontFamily::BOLD);


### PR DESCRIPTION
## Summary

Three small home-screen fixes that together address the issues caught after #11 merged:

1. **Cover-placeholder title capped at 4 lines.** \`LyraFlowTheme::drawShelfStrip\` allowed up to 10 wrapped lines for the placeholder title, so long boxed-set names (e.g. "George R. R. Martin's A Game of Thrones 5-Book Boxed Set") filled the cell with wrapped small-bold text instead of reading as a clean "missing cover" hint. Matches MinimalTheme's existing 4-line convention.

2. **Size-specific thumb-failed markers (CoverThumbStatus v2 → v3).** The thumb-failure marker was previously global per book — one transient memory-pressure failure during a multi-book Collections grid load (e.g. 9 covers in flight at 3x3) would permanently poison the book against ALL future thumb-gen attempts at ANY size. Carousel kept working only because its 296x468 / 200x390 thumbs had been generated in an earlier session and were cached on disk (the render path reads cached files directly).

   Marker filename moves from \`thumb_failed_v2.marker\` to \`thumb_failed_v3_<W>x<H>.marker\` so failures at one size don't block other sizes. The v2 → v3 suffix bump invalidates every existing global marker, giving every book a fresh chance to thumbnail at current cell sizes. All 23 call sites in HomeActivity / RecentBooksGridActivity updated to pass the W,H they're requesting.

3. **DOWN navigates partial last rows instead of no-op.** In a 2x2 bookshelf with 3 books on the page, pressing DOWN from the top-right cell did nothing — the same-column slot in the next row had no book, so \`moveVerticalInGrid\` skipped the candidate return and fell through to next-page wrap. Same in a 3x3 with 5 books. Snap to the rightmost cell of the partial next row when the same-column slot is past totalItems.

## Test plan

- [x] \`pio run -e tiny\` clean
- [x] On-device read of a previously-stuck book (GoT boxed set) — cover now loads in Collections after the v2 marker is bypassed
- [x] On-device verify the 4-line cap actually trims long titles in the placeholder
- [x] On-device verify DOWN from top-right in 2x2 / 3x3 partial-grid layouts lands on the correct partial-row cell, and the fully-populated case is unchanged

## Follow-ups (not in this PR)

- Off-device .cmb pre-bake CLI tool
- Slice 2 follow-ups: wire image/hr/anchor blocks through ChapterCmbSlimBuilder
- Embed parsed CSS rules in .cmb (format extension to land first-open at ~4s for pre-baked books)