### PR TITLE
feat(cmb): wire image / hr / page break / anchors through ChapterCmbSlimBuilder

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -1212,6 +1212,15 @@ bool Epub::getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset
   return ZipFile(filepath).getLocalHeaderOffset(path.c_str(), offset);
 }
 
+bool Epub::readItemContentsToStreamAtOffset(const uint32_t localHeaderOffset, Print& out, const size_t chunkSize) const {
+  return ZipFile(filepath).readFileToStreamAtOffset(localHeaderOffset, out, chunkSize);
+}
+
+bool Epub::getZipEntryFilenameAtOffset(const uint32_t localHeaderOffset, std::string* filename) const {
+  if (filename == nullptr) return false;
+  return ZipFile(filepath).getFilenameAtOffset(localHeaderOffset, filename);
+}
+
 namespace {
 const std::string kEmptyString;
 }  // namespace

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -140,6 +140,17 @@ class Epub {
   // bytes from the EPUB without walking the central directory at
   // display time. Path normalised the same way as readItemContents*.
   bool getZipLocalHeaderOffset(const std::string& itemHref, uint32_t* offset) const;
+  // CrumBLE: companion to getZipLocalHeaderOffset for the reader side.
+  // Streams the entry's inflated bytes to `out`, seeking to
+  // `localHeaderOffset` directly instead of walking the central
+  // directory. Used by ChapterCmbSlimBuilder when rendering image
+  // blocks (the .cmb image-ref table carries the offset).
+  bool readItemContentsToStreamAtOffset(uint32_t localHeaderOffset, Print& out, size_t chunkSize) const;
+  // Recover the entry's filename from its local file header. Used to
+  // pick the right image decoder by extension once we've pulled bytes
+  // out at a known offset (the .cmb image-ref table doesn't store
+  // the filename to save space).
+  bool getZipEntryFilenameAtOffset(uint32_t localHeaderOffset, std::string* filename) const;
   // CrumBLE #134: accessors for metadata fields the .cmb converter
   // needs to capture into the .cmb v3 metadata blob. Cover href and
   // text-reference href live inside the BookMetadataCache; the CSS

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -752,9 +752,15 @@ bool Section::tryBuildSectionFromCmb(const std::string& cmbPath, const std::stri
   LOG_DBG("SCT", "CMB build start: spine=%d free=%u maxAlloc=%u", spineIndex, ESP.getFreeHeap(),
           ESP.getMaxAllocHeap());
 
+  // Image cache prefix mirrors the XHTML path: <bookCache>/img_<spine>_<n><ext>.
+  // Files are written per chapter and survive until the next section
+  // rebuild (which removes the sections/ dir; the imgs persist as small
+  // siblings -- acceptable churn for the BLE-friendly cold-load path).
+  const std::string cmbImageBasePath = epub->getCachePath() + "/img_" + std::to_string(spineIndex) + "_";
   ChapterCmbSlimBuilder builder(
-      cmbPath, renderer, fontId, lineCompression, extraParagraphSpacing, forceParagraphIndents, paragraphAlignment,
-      viewportWidth, viewportHeight, hyphenationEnabled, bionicReadingEnabled, guideReadingEnabled, spineIndex,
+      epub.get(), cmbPath, renderer, fontId, lineCompression, extraParagraphSpacing, forceParagraphIndents,
+      paragraphAlignment, viewportWidth, viewportHeight, hyphenationEnabled, bionicReadingEnabled,
+      guideReadingEnabled, spineIndex, cmbImageBasePath,
       [this, &lut](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex) {
         lut.push_back({this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex});
       },

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -25,7 +25,13 @@ constexpr uint32_t SECTION_CACHE_MAGIC = 0x535843FF;  // bytes: 0xFF, "CXS"
 // cut) or by the XHTML fallback. Without this bump, existing v38 caches
 // silently mask the new path and we never see what slice 2 actually
 // renders.
-constexpr uint8_t SECTION_FILE_VERSION = 39;
+// v40: invalidate every v39 cache because ChapterCmbSlimBuilder now
+// handles kCmbBlockImage / kCmbBlockHr / kCmbBlockPageBreak / anchor
+// ids. v39 caches built by the text-only-only builder are missing
+// images, hrs, page breaks, and the anchor table even though the .cmb
+// has all of it -- the on-disk section bytes look identical, so the
+// only signal we have to force a rebuild is the version constant.
+constexpr uint8_t SECTION_FILE_VERSION = 40;
 // How much the largest free block must have grown since a degraded build before
 // we bother rebuilding it for images (avoids rebuild churn on tiny variations).
 constexpr uint32_t SECTION_DEGRADED_REBUILD_MARGIN = 12 * 1024;

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
@@ -4,11 +4,16 @@
 #include <CmbReader.h>
 #include <EpdFontFamily.h>
 #include <GfxRenderer.h>
+#include <HalStorage.h>
 #include <Logging.h>
 
 #include <new>
 
+#include "Epub.h"
 #include "Epub/Page.h"
+#include "Epub/blocks/ImageBlock.h"
+#include "Epub/converters/ImageDecoderFactory.h"
+#include "Epub/converters/ImageToFramebufferDecoder.h"
 #include "Epub/css/CssStyle.h"
 
 namespace {
@@ -119,13 +124,17 @@ bool ChapterCmbSlimBuilder::parseAndBuildPages() {
       case cmb::kCmbBlockPageBreak:
         processPageBreak();
         break;
-      case cmb::kCmbBlockImage:
-        // Image rendering not wired through CMB yet -- the converter
-        // captures image_key + ZIP local-header offset, but the on-
-        // device decode + framebuffer + PageImage pipeline is a
-        // larger change (matches ChapterHtmlSlimParser::on_start's
-        // <img> path). Skipped for now; the slot stays blank.
+      case cmb::kCmbBlockImage: {
+        cmb::CmbImageRef ref{};
+        if (epub != nullptr && reader.image_ref(paragraph.image_key, ref)) {
+          if (!processImageBlock(ref.local_header_offset, ref.width, ref.height)) {
+            return false;
+          }
+        }
+        // Unknown image_key or missing epub: skip silently. The slot
+        // collapses; surrounding paragraphs flow normally.
         break;
+      }
       default:
         // Unknown future block type. CMB format reserves unknown
         // tags as "skip via length prefix"; the reader already
@@ -339,6 +348,128 @@ void ChapterCmbSlimBuilder::processPageBreak() {
     currentPage.reset();
     currentPageNextY = 0;
   }
+}
+
+bool ChapterCmbSlimBuilder::processImageBlock(const uint32_t localHeaderOffset, const uint16_t declaredWidth,
+                                              const uint16_t declaredHeight) {
+  if (epub == nullptr) return true;  // silently skip when caller didn't pass an Epub
+
+  // Recover the entry's filename from its local file header so we know
+  // which decoder to dispatch to (the factory keys off extension).
+  std::string entryName;
+  if (!epub->getZipEntryFilenameAtOffset(localHeaderOffset, &entryName) || entryName.empty()) {
+    LOG_DBG("ECB", "image at offset %u: filename lookup failed, skipping", localHeaderOffset);
+    return true;
+  }
+  std::string ext;
+  const size_t dot = entryName.rfind('.');
+  if (dot != std::string::npos) ext = entryName.substr(dot);
+  if (!ImageDecoderFactory::isFormatSupported(ext)) {
+    LOG_DBG("ECB", "image '%s': format not supported, skipping", entryName.c_str());
+    return true;
+  }
+
+  // Extract the inflated image bytes to a per-chapter cache file. ImageBlock
+  // reads from this path at render time (decoder reopens it).
+  const std::string cachedImagePath = imageBasePath + std::to_string(imageCounter++) + ext;
+  {
+    FsFile cachedImageFile;
+    if (!Storage.openFileForWrite("ECB", cachedImagePath, cachedImageFile)) {
+      LOG_ERR("ECB", "could not open image cache file %s", cachedImagePath.c_str());
+      return true;
+    }
+    constexpr size_t kExtractChunkSize = 1024;
+    const bool extractedOk = epub->readItemContentsToStreamAtOffset(localHeaderOffset, cachedImageFile, kExtractChunkSize);
+    cachedImageFile.flush();
+    cachedImageFile.close();
+    if (!extractedOk) {
+      LOG_ERR("ECB", "image extract from offset %u failed", localHeaderOffset);
+      Storage.remove(cachedImagePath.c_str());
+      return true;
+    }
+    delay(50);  // SD card sync, same defensive pause as the XHTML path
+  }
+
+  // Pull source dimensions from the just-extracted file. EPUBs often
+  // declare width/height in markup (carried through to CmbImageRef);
+  // fall back to those when the decoder can't probe.
+  ImageDimensions dims = {0, 0};
+  ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(cachedImagePath);
+  if (decoder == nullptr || !decoder->getDimensions(cachedImagePath, dims)) {
+    if (declaredWidth > 0 && declaredHeight > 0) {
+      dims.width = declaredWidth;
+      dims.height = declaredHeight;
+    } else {
+      LOG_DBG("ECB", "image '%s': dims unknown, skipping", cachedImagePath.c_str());
+      Storage.remove(cachedImagePath.c_str());
+      return true;
+    }
+  }
+
+  // Fit to viewport preserving aspect ratio (no CSS path -- CMB doesn't
+  // carry per-image style).
+  const int maxW = viewportWidth;
+  const int maxH = viewportHeight;
+  int displayW = dims.width;
+  int displayH = dims.height;
+  if (displayW <= 0 || displayH <= 0) {
+    Storage.remove(cachedImagePath.c_str());
+    return true;
+  }
+  if (displayW > maxW || displayH > maxH) {
+    const float scaleX = displayW > maxW ? static_cast<float>(maxW) / displayW : 1.0f;
+    const float scaleY = displayH > maxH ? static_cast<float>(maxH) / displayH : 1.0f;
+    const float scale = std::min(scaleX, scaleY);
+    displayW = std::max(1, static_cast<int>(displayW * scale + 0.5f));
+    displayH = std::max(1, static_cast<int>(displayH * scale + 0.5f));
+  }
+
+  // Make sure we have a page; flush if the image won't fit in remaining
+  // vertical space and the page isn't empty (avoid leading-blank pages).
+  if (!currentPage) {
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      Storage.remove(cachedImagePath.c_str());
+      return false;
+    }
+    currentPageNextY = 0;
+  }
+  if (!currentPage->elements.empty() && currentPageNextY + displayH > viewportHeight) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      Storage.remove(cachedImagePath.c_str());
+      return false;
+    }
+    currentPageNextY = 0;
+  }
+
+  // Center horizontally; if the image is taller than the page, just cap
+  // it at the viewport height (matches the XHTML parser's fallback).
+  const int16_t xPos = static_cast<int16_t>((viewportWidth - displayW) / 2);
+  const int16_t finalH = static_cast<int16_t>(std::min(displayH, viewportHeight - currentPageNextY));
+  if (finalH <= 0) {
+    Storage.remove(cachedImagePath.c_str());
+    return true;
+  }
+
+  auto imageBlock = std::shared_ptr<ImageBlock>(new (std::nothrow) ImageBlock(cachedImagePath, displayW, finalH));
+  if (!imageBlock) {
+    lowMemoryAbort = true;
+    Storage.remove(cachedImagePath.c_str());
+    return false;
+  }
+  auto pageImage = std::shared_ptr<PageImage>(new (std::nothrow) PageImage(imageBlock, xPos, currentPageNextY));
+  if (!pageImage) {
+    lowMemoryAbort = true;
+    return false;
+  }
+  currentPage->elements.push_back(pageImage);
+  currentPageNextY = static_cast<int16_t>(currentPageNextY + finalH);
+  return true;
 }
 
 void ChapterCmbSlimBuilder::recordAnchor(const std::string& anchorId) {

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.cpp
@@ -107,15 +107,39 @@ bool ChapterCmbSlimBuilder::parseAndBuildPages() {
       return false;
     }
 
-    if (paragraph.type == cmb::kCmbBlockText) {
-      if (!processTextParagraph(paragraph.text, paragraph.runs, paragraph.alignment, paragraph.heading_level)) {
-        return false;
-      }
-    } else {
-      // kCmbBlockImage / kCmbBlockHr / kCmbBlockPageBreak: not handled
-      // in slice 2 attempt A. Silently skipped -- pages get smaller but
-      // textual content is intact. If the result looks wrong the caller
-      // falls back to the XHTML parser.
+    switch (paragraph.type) {
+      case cmb::kCmbBlockText:
+        if (!processTextParagraph(paragraph.text, paragraph.runs, paragraph.alignment, paragraph.heading_level)) {
+          return false;
+        }
+        break;
+      case cmb::kCmbBlockHr:
+        processHorizontalRule();
+        break;
+      case cmb::kCmbBlockPageBreak:
+        processPageBreak();
+        break;
+      case cmb::kCmbBlockImage:
+        // Image rendering not wired through CMB yet -- the converter
+        // captures image_key + ZIP local-header offset, but the on-
+        // device decode + framebuffer + PageImage pipeline is a
+        // larger change (matches ChapterHtmlSlimParser::on_start's
+        // <img> path). Skipped for now; the slot stays blank.
+        break;
+      default:
+        // Unknown future block type. CMB format reserves unknown
+        // tags as "skip via length prefix"; the reader already
+        // returns out.type set to the unknown value so we can just
+        // ignore here.
+        break;
+    }
+
+    // Record the anchor at whichever page the previous block landed
+    // on. Anchors fire regardless of block type so footnote targets
+    // (typically the first text paragraph of the chapter) and hr-
+    // separated sections both resolve correctly.
+    if (!paragraph.anchor_id.empty()) {
+      recordAnchor(paragraph.anchor_id);
     }
 
     if (lowMemoryAbort) {
@@ -257,4 +281,71 @@ void ChapterCmbSlimBuilder::addLineToPage(std::shared_ptr<TextBlock> line) {
   const int16_t xOffset = line->getBlockStyle().leftInset();
   currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
   currentPageNextY = static_cast<int16_t>(currentPageNextY + lineHeight);
+}
+
+void ChapterCmbSlimBuilder::processHorizontalRule() {
+  // Sizing mirrors ChapterHtmlSlimParser::emitHorizontalRule: 1/4 of the
+  // available content width, centered, 2 px thick, with a half-line of
+  // breathing room above and below.
+  if (!currentPage) {
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      return;
+    }
+    currentPageNextY = 0;
+  }
+
+  const auto lineHeight = static_cast<int16_t>(renderer.getLineHeight(fontId) * lineCompression + 0.5f);
+  const int16_t verticalSpacing = static_cast<int16_t>(lineHeight / 2);
+  constexpr uint8_t kRuleThickness = 2;
+  const int16_t availableWidth = std::max<int16_t>(1, static_cast<int16_t>(viewportWidth));
+  const int16_t width = std::max<int16_t>(1, static_cast<int16_t>(availableWidth / 4));
+  const int16_t xPos = static_cast<int16_t>((availableWidth - width) / 2);
+  const int16_t totalHeight = static_cast<int16_t>(verticalSpacing + kRuleThickness + verticalSpacing);
+
+  // Flush the page if the rule + its spacing won't fit; same rule the
+  // XHTML emitter uses.
+  if (!currentPage->elements.empty() && currentPageNextY + totalHeight > viewportHeight) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset(new (std::nothrow) Page());
+    if (!currentPage) {
+      lowMemoryAbort = true;
+      return;
+    }
+    currentPageNextY = 0;
+  }
+
+  currentPageNextY = static_cast<int16_t>(currentPageNextY + verticalSpacing);
+  auto pageRule = std::shared_ptr<PageHorizontalRule>(
+      new (std::nothrow) PageHorizontalRule(width, kRuleThickness, xPos, currentPageNextY));
+  if (!pageRule) {
+    lowMemoryAbort = true;
+    return;
+  }
+  currentPage->elements.push_back(pageRule);
+  currentPageNextY = static_cast<int16_t>(currentPageNextY + kRuleThickness + verticalSpacing);
+}
+
+void ChapterCmbSlimBuilder::processPageBreak() {
+  // Force a page boundary even if the current page isn't full. Skips
+  // entirely when the current page is empty (a leading <mbp:pagebreak/>
+  // would otherwise emit an empty page that the reader would then
+  // skip-display).
+  if (currentPage && !currentPage->elements.empty()) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset();
+    currentPageNextY = 0;
+  }
+}
+
+void ChapterCmbSlimBuilder::recordAnchor(const std::string& anchorId) {
+  // Anchor lands on whichever page the previously-emitted block ended
+  // up on. completedPageCount == the next page index since pages are
+  // counted post-flush, so we use it as the target page for any anchor
+  // that immediately precedes the next block (matches the XHTML
+  // parser's pendingAnchorId -> next-block-page contract).
+  anchorData.push_back({anchorId, static_cast<uint16_t>(completedPageCount)});
 }

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
@@ -33,20 +33,24 @@
 
 class Page;
 class GfxRenderer;
+class Epub;
 
 class ChapterCmbSlimBuilder {
  public:
   using PageCompleteFn = std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)>;
 
-  ChapterCmbSlimBuilder(const std::string& cmbPath, GfxRenderer& renderer, int fontId, float lineCompression,
+  ChapterCmbSlimBuilder(Epub* epub, const std::string& cmbPath, GfxRenderer& renderer, int fontId, float lineCompression,
                         bool extraParagraphSpacing, bool forceParagraphIndents, uint8_t paragraphAlignment,
                         uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
                         bool bionicReadingEnabled, bool guideReadingEnabled, int chapterIdx,
-                        PageCompleteFn completePageFn, const std::function<void()>& popupFn = nullptr)
-      : cmbPath(cmbPath),
+                        std::string imageBasePath, PageCompleteFn completePageFn,
+                        const std::function<void()>& popupFn = nullptr)
+      : epub(epub),
+        cmbPath(cmbPath),
         renderer(renderer),
         completePageFn(std::move(completePageFn)),
         popupFn(popupFn),
+        imageBasePath(std::move(imageBasePath)),
         fontId(fontId),
         lineCompression(lineCompression),
         extraParagraphSpacing(extraParagraphSpacing),
@@ -80,10 +84,15 @@ class ChapterCmbSlimBuilder {
   bool wasLowMemoryAbortTriggered() const { return lowMemoryAbort; }
 
  private:
+  Epub* epub;  // non-owning; lifetime guaranteed by caller (Section)
   const std::string& cmbPath;
   GfxRenderer& renderer;
   PageCompleteFn completePageFn;
   std::function<void()> popupFn;
+  // Prefix for per-chapter image cache files (same naming pattern the
+  // XHTML parser uses): <imageBasePath><counter><ext>
+  std::string imageBasePath;
+  uint16_t imageCounter = 0;
   int fontId;
   float lineCompression;
   bool extraParagraphSpacing;
@@ -124,6 +133,17 @@ class ChapterCmbSlimBuilder {
   // Hard page break: flush whatever's on currentPage and start a fresh one
   // even if the current one isn't full. Matches HTML's <mbp:pagebreak/>.
   void processPageBreak();
+
+  // Emit one CMB image block. localHeaderOffset comes from the .cmb
+  // image-ref table (resolved by the caller). Pulls inflated bytes via
+  // Epub::readItemContentsToStreamAtOffset, picks a decoder by extension
+  // (recovered from the LFH), and places a PageImage onto the current
+  // page. Sized to fit the viewport preserving aspect ratio -- no
+  // CSS-driven sizing since CMB doesn't carry per-image style info yet.
+  // Returns false on OOM during page/image allocation; lesser failures
+  // (decoder missing, image extract fails) just skip the image and
+  // continue with whatever paragraphs follow.
+  bool processImageBlock(uint32_t localHeaderOffset, uint16_t declaredWidth, uint16_t declaredHeight);
 
   // Record the anchor at the current page boundary. Called for every
   // CMB paragraph that has a non-empty anchor_id, so in-book fragment

--- a/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
+++ b/lib/Epub/Epub/parsers/ChapterCmbSlimBuilder.h
@@ -67,11 +67,15 @@ class ChapterCmbSlimBuilder {
   // the XHTML parser path.
   bool parseAndBuildPages();
 
-  // Empty placeholders for Section.cpp parity. Anchors/footnotes aren't
-  // yet wired through .cmb -- the returned vectors stay empty so
-  // Section.cpp writes the same zero-entry tables it would for an
-  // anchor-less HTML chapter.
+  // (anchor_id, page_index) pairs collected as paragraphs were emitted.
+  // Populated when a CMB paragraph carries a non-empty anchor_id (set by
+  // the converter from the source XHTML's `id` attribute). Used by
+  // Section's anchor-table writer to support in-book fragment
+  // navigation (footnote -> target, TOC anchor -> chapter mid-point).
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
+  // Always false: the CMB path has no equivalent of the XHTML parser's
+  // "images suppressed under BLE" fallback yet (image blocks are
+  // skipped outright, not degraded). Kept for Section.cpp API parity.
   bool wasLowMemoryFallbackTriggered() const { return false; }
   bool wasLowMemoryAbortTriggered() const { return lowMemoryAbort; }
 
@@ -112,6 +116,19 @@ class ChapterCmbSlimBuilder {
   // Emit one CMB text paragraph. Returns false on OOM.
   bool processTextParagraph(const std::string& text, const std::vector<cmb::CmbStyleRun>& runs, uint8_t alignment,
                             uint8_t headingLevel);
+
+  // Emit a horizontal rule onto the current page, breaking the page if
+  // the rule + its spacing would overflow viewportHeight.
+  void processHorizontalRule();
+
+  // Hard page break: flush whatever's on currentPage and start a fresh one
+  // even if the current one isn't full. Matches HTML's <mbp:pagebreak/>.
+  void processPageBreak();
+
+  // Record the anchor at the current page boundary. Called for every
+  // CMB paragraph that has a non-empty anchor_id, so in-book fragment
+  // navigation (footnote -> target) lands on the right page.
+  void recordAnchor(const std::string& anchorId);
 
   // Run layout on the supplied ParsedText and append the resulting
   // lines to currentPage; flushes pages when they overflow.

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -584,3 +584,171 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
   LOG_ERR("ZIP", "Unsupported compression method");
   return false;
 }
+
+bool ZipFile::loadFileStatSlimFromLocalHeader(const uint32_t localHeaderOffset, FileStatSlim* fileStat) {
+  const ScopedOpenClose zip{*this};
+  if (!zip) return false;
+
+  constexpr auto kLocalHeaderSize = 30;
+  uint8_t lh[kLocalHeaderSize];
+  if (!file.seek(localHeaderOffset)) {
+    LOG_ERR("ZIP", "seek to local header at %u failed", localHeaderOffset);
+    return false;
+  }
+  if (file.read(lh, kLocalHeaderSize) != kLocalHeaderSize) {
+    LOG_ERR("ZIP", "short read of local header at %u", localHeaderOffset);
+    return false;
+  }
+  if (lh[0] != 0x50 || lh[1] != 0x4b || lh[2] != 0x03 || lh[3] != 0x04) {
+    LOG_ERR("ZIP", "bad local header magic at %u", localHeaderOffset);
+    return false;
+  }
+  const uint16_t generalFlag = lh[6] | (static_cast<uint16_t>(lh[7]) << 8);
+  // Bit 3 = sizes + CRC stored in a post-data descriptor; the LFH fields
+  // are zero. We can't extract the entry without consulting the central
+  // directory, which defeats the offset-keyed read. The converter
+  // shouldn't be emitting offsets for these entries; bail loudly.
+  if (generalFlag & 0x0008) {
+    LOG_ERR("ZIP", "LFH at %u has data-descriptor flag set; unsupported for offset reads", localHeaderOffset);
+    return false;
+  }
+  fileStat->method = lh[8] | (static_cast<uint16_t>(lh[9]) << 8);
+  fileStat->compressedSize =
+      lh[18] | (static_cast<uint32_t>(lh[19]) << 8) | (static_cast<uint32_t>(lh[20]) << 16) |
+      (static_cast<uint32_t>(lh[21]) << 24);
+  fileStat->uncompressedSize =
+      lh[22] | (static_cast<uint32_t>(lh[23]) << 8) | (static_cast<uint32_t>(lh[24]) << 16) |
+      (static_cast<uint32_t>(lh[25]) << 24);
+  fileStat->localHeaderOffset = localHeaderOffset;
+  return true;
+}
+
+bool ZipFile::readFileToStreamAtOffset(const uint32_t localHeaderOffset, Print& out, const size_t chunkSize) {
+  const ScopedOpenClose zip{*this};
+  if (!zip) return false;
+
+  FileStatSlim fileStat = {};
+  if (!loadFileStatSlimFromLocalHeader(localHeaderOffset, &fileStat)) return false;
+
+  const long fileOffset = getDataOffset(fileStat);
+  if (fileOffset < 0) return false;
+
+  file.seek(fileOffset);
+  const auto deflatedDataSize = fileStat.compressedSize;
+  const auto inflatedDataSize = fileStat.uncompressedSize;
+
+  // STORED: passthrough read, identical to readFileToStream's STORED branch.
+  if (fileStat.method == ZIP_METHOD_STORED) {
+    const auto buffer = static_cast<uint8_t*>(malloc(chunkSize));
+    if (!buffer) {
+      LOG_ERR("ZIP", "Failed to allocate read buffer at offset %u", localHeaderOffset);
+      return false;
+    }
+    size_t remaining = inflatedDataSize;
+    while (remaining > 0) {
+      const size_t want = remaining < chunkSize ? remaining : chunkSize;
+      const size_t got = file.read(buffer, want);
+      if (got == 0) {
+        LOG_ERR("ZIP", "short read while streaming offset %u", localHeaderOffset);
+        free(buffer);
+        return false;
+      }
+      if (out.write(buffer, got) != got) {
+        LOG_ERR("ZIP", "stream write failed during offset read at %u", localHeaderOffset);
+        free(buffer);
+        return false;
+      }
+      remaining -= got;
+    }
+    free(buffer);
+    return true;
+  }
+
+  if (fileStat.method == ZIP_METHOD_DEFLATED) {
+    ZipInflateCtx ctx;
+    ctx.file = &file;
+    ctx.fileRemaining = deflatedDataSize;
+    if (!ctx.reader.init(true, inflatedDataSize)) {
+      LOG_ERR("ZIP", "inflate init failed at offset %u (free=%u maxAlloc=%u dict=%u)", localHeaderOffset,
+              ESP.getFreeHeap(), ESP.getMaxAllocHeap(), static_cast<unsigned>(inflatedDataSize));
+      return false;
+    }
+    auto* readBuf = static_cast<uint8_t*>(malloc(chunkSize));
+    if (!readBuf) {
+      LOG_ERR("ZIP", "alloc read buffer failed (offset=%u chunk=%zu)", localHeaderOffset, chunkSize);
+      return false;
+    }
+    auto* outBuf = static_cast<uint8_t*>(malloc(chunkSize));
+    if (!outBuf) {
+      LOG_ERR("ZIP", "alloc output buffer failed (offset=%u chunk=%zu)", localHeaderOffset, chunkSize);
+      free(readBuf);
+      return false;
+    }
+    ctx.readBuf = readBuf;
+    ctx.readBufSize = chunkSize;
+    ctx.reader.setReadCallback(zipReadCallback);
+
+    bool success = false;
+    size_t totalProduced = 0;
+    while (true) {
+      size_t produced;
+      const InflateStatus status = ctx.reader.readAtMost(outBuf, chunkSize, &produced);
+      totalProduced += produced;
+      if (totalProduced > static_cast<size_t>(inflatedDataSize)) {
+        LOG_ERR("ZIP", "inflate overshoot at offset %u (%zu > %u)", localHeaderOffset, totalProduced,
+                inflatedDataSize);
+        break;
+      }
+      if (produced > 0 && out.write(outBuf, produced) != produced) {
+        LOG_ERR("ZIP", "stream write failed during inflate at offset %u", localHeaderOffset);
+        break;
+      }
+      if (status == InflateStatus::Done) {
+        if (totalProduced != static_cast<size_t>(inflatedDataSize)) {
+          LOG_ERR("ZIP", "inflate size mismatch at offset %u (expected %u got %zu)", localHeaderOffset,
+                  inflatedDataSize, totalProduced);
+          break;
+        }
+        success = true;
+        break;
+      }
+      if (status == InflateStatus::Error) {
+        LOG_ERR("ZIP", "inflate error at offset %u", localHeaderOffset);
+        break;
+      }
+    }
+    free(outBuf);
+    free(readBuf);
+    return success;
+  }
+
+  LOG_ERR("ZIP", "unsupported method %u at offset %u", fileStat.method, localHeaderOffset);
+  return false;
+}
+
+bool ZipFile::getFilenameAtOffset(const uint32_t localHeaderOffset, std::string* filename) {
+  const ScopedOpenClose zip{*this};
+  if (!zip) return false;
+  if (!filename) return false;
+
+  constexpr auto kLocalHeaderSize = 30;
+  uint8_t lh[kLocalHeaderSize];
+  if (!file.seek(localHeaderOffset)) return false;
+  if (file.read(lh, kLocalHeaderSize) != kLocalHeaderSize) return false;
+  if (lh[0] != 0x50 || lh[1] != 0x4b || lh[2] != 0x03 || lh[3] != 0x04) {
+    LOG_ERR("ZIP", "bad local header magic at %u (filename read)", localHeaderOffset);
+    return false;
+  }
+  const uint16_t fnLen = lh[26] | (static_cast<uint16_t>(lh[27]) << 8);
+  if (fnLen == 0) {
+    filename->clear();
+    return true;
+  }
+  filename->resize(fnLen);
+  if (file.read(reinterpret_cast<uint8_t*>(filename->data()), fnLen) != fnLen) {
+    LOG_ERR("ZIP", "short read of filename at %u (len=%u)", localHeaderOffset, fnLen);
+    filename->clear();
+    return false;
+  }
+  return true;
+}

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -48,6 +48,13 @@ class ZipFile {
   bool lastCentralDirPosValid = false;
 
   bool loadFileStatSlim(const char* filename, FileStatSlim* fileStat);
+  // Populate a FileStatSlim from the bytes at a known local-file-header
+  // offset, without consulting the central directory. Used by the .cmb
+  // image path -- the converter captured the offset at write time so
+  // the reader can pull image bytes directly. Returns false on bad
+  // magic, unsupported flag combinations (data descriptor without
+  // sizes in LFH), or read errors.
+  bool loadFileStatSlimFromLocalHeader(uint32_t localHeaderOffset, FileStatSlim* fileStat);
   long getDataOffset(const FileStatSlim& fileStat);
   bool loadZipDetails();
 
@@ -80,4 +87,14 @@ class ZipFile {
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
   bool readFileToStream(const char* filename, Print& out, size_t chunkSize);
+  // Offset-keyed read: extract + inflate the entry whose local-file-header
+  // lives at `localHeaderOffset` (typically read out of a .cmb image ref).
+  // Skips the central-dir lookup entirely. Returns false on bad LFH magic,
+  // unsupported flag combinations, or any underlying read/inflate failure.
+  bool readFileToStreamAtOffset(uint32_t localHeaderOffset, Print& out, size_t chunkSize);
+  // Read the entry's filename out of the local file header at the given
+  // offset. Used by the .cmb image path to recover the file extension
+  // (the decoder factory dispatches by extension). Returns false on bad
+  // magic or short read; *filename is left unspecified on failure.
+  bool getFilenameAtOffset(uint32_t localHeaderOffset, std::string* filename);
 };


### PR DESCRIPTION
## Summary

Closes the four "silently skipped" block-type gaps from slice 2 attempt A (#11). The CMB-first build path used to render only \`kCmbBlockText\`; everything else (\`kCmbBlockImage\`, \`kCmbBlockHr\`, \`kCmbBlockPageBreak\`, and per-paragraph \`anchor_id\`s) was dropped on the floor. Books with inline images would render text-only chapters; in-book fragment navigation (footnote → target) didn't work over CMB.

This PR makes \`ChapterCmbSlimBuilder\` render all of them, matching the visual output of the XHTML fallback for the typical case.

## Commits (read in order)

1. **\`feat(cmb): wire HR + page break + anchors\`** — straightforward block dispatch:
   - \`kCmbBlockHr\` → \`PageHorizontalRule\` with the same sizing the XHTML parser uses (1/4 viewport, centered, 2 px, half-line top/bottom spacing).
   - \`kCmbBlockPageBreak\` → flushes the current page when non-empty.
   - Per-paragraph \`anchor_id\` → \`anchorData\`, which \`Section::tryBuildSectionFromCmb\` already serializes into the section file's anchor table.

2. **\`feat(zip): offset-keyed read + LFH filename getter\`** — new \`ZipFile\` primitives that let the reader pull entry bytes via a known local-header offset (the .cmb image-ref table stores these):
   - \`readFileToStreamAtOffset(uint32_t, Print&, size_t)\` — extract + inflate by offset, no central-dir walk.
   - \`getFilenameAtOffset(uint32_t, *string)\` — recover the filename for decoder dispatch.

3. **\`feat(epub): wrappers for offset-keyed ZIP reads\`** — thin \`Epub::\` forwarders so the builder doesn't have to know about \`ZipFile\` directly.

4. **\`feat(cmb): render image blocks via ChapterCmbSlimBuilder\`** — the actual image path:
   - Builder constructor now takes \`Epub*\` + \`imageBasePath\` (cache prefix mirrors the XHTML pattern: \`<bookCache>/img_<spine>_<n><ext>\`).
   - \`kCmbBlockImage\` → resolve image_key to \`CmbImageRef\`, pull bytes via \`readItemContentsToStreamAtOffset\`, recover extension via \`getZipEntryFilenameAtOffset\`, dispatch decoder, build \`ImageBlock\` + \`PageImage\`. Sized fit-to-viewport with aspect ratio preserved (no CSS path).
   - Soft-skip on decoder-miss / extract-failure / dims-unknown; only OOM during page/block allocation propagates as a hard failure (→ XHTML fallback).

5. **\`chore(cmb): bump SECTION_FILE_VERSION to 40\`** — v39 section caches were built when the builder was text-only-only. v40 invalidates them so the next page-turn into any chapter rebuilds via the new image/hr/anchor-capable path. This is the only way to expose the new behaviour without bytecode-incompatible section-file changes.

## Test plan

- [x] \`pio run -e tiny\` clean.
- [x] On-device: Iron Flame ch1 pg1 (previously missing its inline image) renders the image after v40 forces a rebuild via the new CMB image path.
- [x] Serial log confirms the v40 invalidation fires for old caches (\`Deserialization failed: Unknown version 39\`).
- [ ] On-device: chapter with \`<hr>\` section breaks shows them.
- [ ] On-device: footnote tap → target anchor lands on the right page over the CMB path.

## Known gaps (out of this PR)

- No CSS-driven image sizing (CMB doesn't carry per-image style info yet — natural fit-to-viewport is the fallback).
- No equivalent of \`ChapterHtmlSlimParser::lowMemoryImageFallback\` -- under BLE pressure, an image extraction failure just skips the image instead of degrading to suppressed-images-but-rendered-text. The XHTML fallback safety net catches this when the chapter build returns false outright.
- LOG_LEVEL=1 means the per-image DBG diagnostics don't appear in tiny-env serial; build with the default/debug envs (LOG_LEVEL=2) to see \`[ECB]\` step-by-step.