### PR TITLE
perf(heap): pool per-book metadata strings to fix file-transfer freeze

### DIFF
--- a/src/CollectionsStore.cpp
+++ b/src/CollectionsStore.cpp
@@ -520,16 +520,19 @@ std::vector<ShelfEntry> CollectionsStore::resolveShelfEntries(const std::string&
   std::vector<ShelfEntry> out;
   out.reserve(paths.size());
   auto& seriesIdx = SeriesIndex::getInstance();
+  auto nameStr = [&](const SeriesEntry* se) { return se ? std::string{seriesIdx.nameOf(*se)} : std::string{}; };
+  auto indexStr = [&](const SeriesEntry* se) { return se ? std::string{seriesIdx.indexOf(*se)} : std::string{}; };
   for (const auto& p : paths) {
     const SeriesEntry* se = seriesIdx.find(p);
-    if (se == nullptr || se->name.empty()) {
+    const std::string seName = nameStr(se);
+    if (se == nullptr || seName.empty()) {
       ShelfEntry e;
       e.firstPath = p;
       e.memberPaths.push_back(p);
       out.push_back(std::move(e));
       continue;
     }
-    const std::string key = SeriesIndex::seriesKey(se->name);
+    const std::string key = SeriesIndex::seriesKey(seName);
     if (seenKeys.count(key)) continue;  // grouped already; subsequent members suppressed.
     seenKeys.insert(key);
 
@@ -537,7 +540,8 @@ std::vector<ShelfEntry> CollectionsStore::resolveShelfEntries(const std::string&
     std::vector<std::string> members;
     for (const auto& q : paths) {
       const SeriesEntry* qse = seriesIdx.find(q);
-      if (qse != nullptr && !qse->name.empty() && SeriesIndex::seriesKey(qse->name) == key) {
+      const std::string qName = nameStr(qse);
+      if (qse != nullptr && !qName.empty() && SeriesIndex::seriesKey(qName) == key) {
         members.push_back(q);
       }
     }
@@ -554,11 +558,11 @@ std::vector<ShelfEntry> CollectionsStore::resolveShelfEntries(const std::string&
     std::sort(members.begin(), members.end(), [&](const std::string& a, const std::string& b) {
       const SeriesEntry* ea = seriesIdx.find(a);
       const SeriesEntry* eb = seriesIdx.find(b);
-      return SeriesIndex::indexLess(ea ? ea->index : "", eb ? eb->index : "");
+      return SeriesIndex::indexLess(indexStr(ea), indexStr(eb));
     });
     ShelfEntry e;
     e.firstPath = members.front();
-    e.seriesName = se->name;
+    e.seriesName = seName;
     e.memberPaths = std::move(members);
     out.push_back(std::move(e));
   }

--- a/src/LibraryIndex.cpp
+++ b/src/LibraryIndex.cpp
@@ -78,6 +78,13 @@ bool iLess(const std::string& a, const std::string& b) {
 
 LibraryIndex LibraryIndex::instance;
 
+uint32_t LibraryIndex::appendPath(std::string_view path) {
+  const uint32_t offset = static_cast<uint32_t>(pathPool.size());
+  pathPool.insert(pathPool.end(), path.begin(), path.end());
+  pathPool.push_back('\0');
+  return offset;
+}
+
 bool LibraryIndex::isBookPath(const std::string& path) {
   if (!(FsHelpers::hasEpubExtension(path) || FsHelpers::hasXtcExtension(path) ||
         FsHelpers::hasTxtExtension(path) || FsHelpers::hasMarkdownExtension(path))) {
@@ -139,46 +146,79 @@ void LibraryIndex::rescan(const std::function<void(int)>& progress) {
   uint64_t nextSeq = 1;
   for (const auto& e : entries) nextSeq = std::max<uint64_t>(nextSeq, e.firstSeenMillis + 1);
 
-  // Incremental diff against the existing index so books keep their order across
-  // walks. Map existing path -> index; a seen flag tracks survivors for pruning.
-  std::unordered_map<std::string, size_t> idxByPath;
-  idxByPath.reserve(entries.size());
-  for (size_t i = 0; i < entries.size(); ++i) idxByPath[entries[i].path] = i;
-  const size_t originalCount = entries.size();
-  std::vector<bool> seen(originalCount, false);
+  // Build a lookup of EXISTING paths (string_view over the current pool) so the
+  // diff doesn't allocate N transient std::string keys -- that was a hidden
+  // fragmentation contributor in the pre-pool implementation.
+  std::unordered_map<std::string_view, size_t> oldIdxByPath;
+  oldIdxByPath.reserve(entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) oldIdxByPath[pathViewOf(entries[i])] = i;
+
+  // We rebuild entries + pathPool atomically rather than mutating in place.
+  // In-place mutation would invalidate string_view keys the moment we appended
+  // a new path into the pool (vector<char> reallocation); the rebuild is also
+  // simpler and gives the allocator a single fresh contiguous block to land in
+  // instead of a stream of incremental grows.
+  std::vector<LibraryEntry> newEntries;
+  std::vector<char> newPool;
+  newEntries.reserve(discovered.size());
+  // Reserve a rough first-cut for the pool so it doesn't realloc on every
+  // append. Average path ~80 chars; round up generously.
+  newPool.reserve(discovered.size() * 96);
+
+  auto appendIntoNewPool = [&newPool](std::string_view path) -> uint32_t {
+    const uint32_t offset = static_cast<uint32_t>(newPool.size());
+    newPool.insert(newPool.end(), path.begin(), path.end());
+    newPool.push_back('\0');
+    return offset;
+  };
 
   for (size_t i = 0; i < discovered.size(); ++i) {
-    auto it = idxByPath.find(discovered[i]);
-    if (it != idxByPath.end()) {
-      seen[it->second] = true;
-      LibraryEntry& e = entries[it->second];
-      // A known path whose size changed = the file was replaced -> re-date it as
-      // freshly added. Skip when the stored size is unknown (0, legacy entry) so
-      // the first scan after upgrade doesn't reshuffle the whole library.
-      if (e.fileSize != 0 && e.fileSize != discoveredSizes[i]) {
+    const std::string& p = discovered[i];
+    auto it = oldIdxByPath.find(std::string_view{p});
+    if (it != oldIdxByPath.end()) {
+      // Carry forward the existing metadata, but re-allocate the path into
+      // the new pool. firstSeenMillis is preserved (the user's "when did this
+      // book first appear" ordering survives the rebuild).
+      const LibraryEntry& old = entries[it->second];
+      LibraryEntry e{};
+      e.pathOffset = appendIntoNewPool(p);
+      e.firstSeenMillis = old.firstSeenMillis;
+      e.fileSize = discoveredSizes[i];
+      // A known path whose size changed = the file was replaced -> re-date it.
+      // Skip when the stored size is unknown (0, legacy entry) so the first
+      // scan after upgrade doesn't reshuffle the whole library.
+      if (old.fileSize != 0 && old.fileSize != discoveredSizes[i]) {
         e.firstSeenMillis = nextSeq++;
       }
-      e.fileSize = discoveredSizes[i];
+      newEntries.push_back(e);
     } else {
-      // Brand-new book -> newest. (push_back may realloc, but idxByPath holds
-      // indices and string-key copies, both unaffected.)
-      entries.push_back({std::move(discovered[i]), nextSeq++, discoveredSizes[i]});
+      // Brand-new book -> newest.
+      LibraryEntry e{};
+      e.pathOffset = appendIntoNewPool(p);
+      e.firstSeenMillis = nextSeq++;
+      e.fileSize = discoveredSizes[i];
+      newEntries.push_back(e);
     }
   }
   if (progress) progress(85);
 
-  // Prune originals whose file disappeared (appended new ones are always
-  // present). Reverse-erase so earlier indices stay valid.
-  for (int i = static_cast<int>(originalCount) - 1; i >= 0; --i) {
-    if (!seen[i]) entries.erase(entries.begin() + i);
-  }
-
-  // Free the walk's scratch vectors before saving so the (streaming) writer runs
-  // with maximum heap headroom.
+  // Free the walk's scratch vectors AND the old pool/entries before saving so
+  // the (streaming) writer runs with maximum heap headroom. The old idx-by-path
+  // map also goes here.
+  std::unordered_map<std::string_view, size_t>().swap(oldIdxByPath);
   discovered.clear();
   discovered.shrink_to_fit();
   discoveredSizes.clear();
   discoveredSizes.shrink_to_fit();
+  // Atomic swap into the new in-place. The old entries/pool's memory drops
+  // back to the allocator as a single contiguous chunk (modulo whatever else
+  // the allocator stitched into it).
+  entries.swap(newEntries);
+  pathPool.swap(newPool);
+  newEntries.clear();
+  newEntries.shrink_to_fit();
+  newPool.clear();
+  newPool.shrink_to_fit();
 
   walkPerformed = true;
   saveToFile();
@@ -193,37 +233,44 @@ void LibraryIndex::rescan(const std::function<void(int)>& progress) {
 std::vector<std::string> LibraryIndex::getAllBookPaths() const {
   std::vector<std::string> out;
   out.reserve(entries.size());
-  for (const auto& e : entries) out.push_back(e.path);
+  for (const auto& e : entries) out.emplace_back(pathOf(e));
   std::sort(out.begin(), out.end(), iLess);
   return out;
 }
 
 std::vector<std::string> LibraryIndex::getRecentlyAddedPaths(int maxCount) const {
-  // Copy + sort the entries by firstSeen DESC, then materialize the
-  // top-N paths. We sort the whole vector rather than partial_sort
-  // because N is small (vector size is bounded by physical books) and
-  // the simpler code is easier to reason about.
-  std::vector<LibraryEntry> sorted = entries;
-  std::sort(sorted.begin(), sorted.end(),
-            [](const LibraryEntry& a, const LibraryEntry& b) { return a.firstSeenMillis > b.firstSeenMillis; });
+  // Sort indices (cheap: 4 bytes each) by the underlying firstSeenMillis,
+  // then materialize the top-N paths out of the pool. Avoids copying the
+  // whole entry vector just to sort it.
+  std::vector<size_t> idx(entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) idx[i] = i;
+  std::sort(idx.begin(), idx.end(), [this](size_t a, size_t b) {
+    return entries[a].firstSeenMillis > entries[b].firstSeenMillis;
+  });
   std::vector<std::string> out;
-  const int n = std::min(maxCount, static_cast<int>(sorted.size()));
+  const int n = std::min(maxCount, static_cast<int>(idx.size()));
   out.reserve(n);
-  for (int i = 0; i < n; ++i) out.push_back(sorted[i].path);
+  for (int i = 0; i < n; ++i) out.emplace_back(pathOf(entries[idx[i]]));
   return out;
 }
 
 uint64_t LibraryIndex::getFirstSeen(const std::string& path) const {
   for (const auto& e : entries) {
-    if (e.path == path) return e.firstSeenMillis;
+    if (path == pathOf(e)) return e.firstSeenMillis;
   }
   return 0;
 }
 
 void LibraryIndex::forgetPath(const std::string& path) {
   auto it = std::find_if(entries.begin(), entries.end(),
-                         [&](const LibraryEntry& e) { return e.path == path; });
+                         [&](const LibraryEntry& e) { return path == pathOf(e); });
   if (it == entries.end()) return;
+  // Just drop the entry from the vector. The pool keeps the dead path
+  // bytes around until the next rescan() rebuilds the pool from scratch
+  // -- the slop is negligible vs. the cost of compacting the pool on
+  // every delete (would require re-targeting every other entry's
+  // pathOffset). Rescan happens on every web-server-exit / explicit
+  // refresh, so the slop never accumulates.
   entries.erase(it);
   saveToFile();
 }
@@ -307,6 +354,7 @@ bool LibraryIndex::loadFromFile() {
   // single-blob JSON index won't match (it starts with '{'), so we reject it
   // and let a rescan rewrite it — without ever slurping the huge old file.
   entries.clear();
+  pathPool.clear();
   LineReader reader(file);
   std::string line;
   bool headerOk = false;
@@ -324,21 +372,27 @@ bool LibraryIndex::loadFromFile() {
     const uint64_t firstSeen = strtoull(line.c_str(), nullptr, 10);
     const size_t tab2 = line.find('\t', tab1 + 1);
     uint32_t fileSize = 0;
-    std::string path;
+    std::string_view path;
     if (tab2 == std::string::npos) {
       // Legacy 2-field line: "<firstSeen>\t<path>" (pre-size index).
-      path = line.substr(tab1 + 1);
+      path = std::string_view{line}.substr(tab1 + 1);
     } else {
       fileSize = static_cast<uint32_t>(strtoul(line.c_str() + tab1 + 1, nullptr, 10));
-      path = line.substr(tab2 + 1);
+      path = std::string_view{line}.substr(tab2 + 1);
     }
     if (path.empty()) continue;
-    entries.push_back({std::move(path), firstSeen, fileSize});
+    LibraryEntry e{};
+    e.pathOffset = appendPath(path);
+    e.firstSeenMillis = firstSeen;
+    e.fileSize = fileSize;
+    entries.push_back(e);
   }
   file.close();
 
   if (!headerOk) {
-    entries.clear();  // legacy/corrupt file — treat as no index, force a rescan
+    // Legacy/corrupt file — treat as no index, force a rescan.
+    entries.clear();
+    pathPool.clear();
     return false;
   }
   LOG_DBG("LIB", "Loaded library index with %zu entries", entries.size());
@@ -364,7 +418,7 @@ bool LibraryIndex::saveToFile() const {
              static_cast<unsigned long>(e.fileSize));
     file.print(numbuf);
     file.print("\t");
-    file.print(e.path.c_str());
+    file.print(pathOf(e));
     file.print("\n");
   }
   file.close();

--- a/src/LibraryIndex.h
+++ b/src/LibraryIndex.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // CrumBLE — persistent index of every book file the device has seen on
@@ -11,11 +12,24 @@
 // walk only needs to happen once (initial discovery) plus on explicit
 // rescan; subsequent boots load the cached index in milliseconds.
 //
-// Memory shape: ~80 bytes per entry (path string + uint64). 500-book
-// library ≈ 40 KB — well within budget on the ESP32-C3.
+// Memory shape: paths are pooled into a single contiguous std::vector<char>
+// (null-terminated, back-to-back) and each LibraryEntry holds an offset
+// into it. Two reasons over the original "std::string per entry":
+//   1. N separate small heap allocs scatter the heap; the freed slots
+//      don't always coalesce into a contiguous block. File-transfer's
+//      WiFi stack needs 8-16 KB contiguous chunks and stalls when the
+//      heap is fragmented even though total free is healthy.
+//   2. releaseMemory() on a pool returns ONE large hole, not N scattered
+//      holes. Reclaim is clean.
+// 500-book library at ~120 chars/path ≈ 60 KB pool + 16 KB entry vector,
+// still within budget on the ESP32-C3.
 
 struct LibraryEntry {
-  std::string path;
+  // Offset into LibraryIndex::pathPool of this entry's null-terminated path.
+  // The pool's contents are stable for the lifetime of one rescan/load;
+  // rescan rebuilds it atomically. Use LibraryIndex::pathOf() to
+  // dereference -- never index the pool directly from outside the class.
+  uint32_t pathOffset = 0;
   // Sort key for "Recently Added" / "Date Added" (DESC = newest first). Despite
   // the legacy name, this is a persistent monotonic "first seen by the device"
   // counter, NOT a wall-clock time: millis() resets each boot, and file
@@ -31,6 +45,11 @@ struct LibraryEntry {
 class LibraryIndex {
   static LibraryIndex instance;
   std::vector<LibraryEntry> entries;
+  // Single contiguous backing buffer for every entry's path. Paths are
+  // appended back-to-back, each null-terminated. Indexed via
+  // entries[i].pathOffset. Stable for the lifetime of one load/rescan;
+  // mutating operations rebuild the pool wholesale.
+  std::vector<char> pathPool;
   bool jsonLoaded = false;  // /.crosspoint/library_index.json has been read
   bool walkPerformed = false;  // an SD walk has run this session (refresh or initial)
   bool freshFirstBoot = false;  // begin() ran with no index file on SD — used to gate welcome UI
@@ -68,15 +87,17 @@ class LibraryIndex {
   // next virtual-collection access) so onExit stays snappy.
   void markStale() { walkPerformed = false; }
 
-  // CrumBLE: free the in-RAM entry vector to reclaim heap. The index can be
-  // tens of KB for a large library (~80 bytes/entry), which is dead weight
-  // while the WiFi web server runs — file transfer is desperately heap-bound
-  // (~25 KB free), so releasing it here roughly doubles available headroom.
-  // The next ensureWalked()/begin() repopulates it from the on-disk JSON plus
-  // an SD walk; web-server exit paths already markStale() so the rebuild is
+  // CrumBLE: free both the entry vector AND the path pool to reclaim heap.
+  // The path pool is the persistent state; releasing it returns one large
+  // contiguous hole (instead of N scattered std::string holes the original
+  // implementation produced). The pool-shape change is what made
+  // file-transfer + WiFi reliably get its 8-16 KB contiguous allocs.
+  // Next ensureWalked()/begin() repopulates from the on-disk JSON plus an
+  // SD walk; web-server exit paths already markStale() so the rebuild is
   // automatic. Only call when nothing is actively reading the index.
   void releaseMemory() {
-    std::vector<LibraryEntry>().swap(entries);  // free capacity, not just size
+    std::vector<LibraryEntry>().swap(entries);
+    std::vector<char>().swap(pathPool);
     jsonLoaded = false;
     walkPerformed = false;
   }
@@ -111,4 +132,13 @@ class LibraryIndex {
   // True if the file extension marks it as one of our supported book
   // formats (.epub / .xtc / .txt / .md / .markdown).
   static bool isBookPath(const std::string& path);
+
+  // Internal helpers for working with the pooled paths.
+  const char* pathOf(const LibraryEntry& e) const { return pathPool.data() + e.pathOffset; }
+  std::string_view pathViewOf(const LibraryEntry& e) const { return std::string_view{pathOf(e)}; }
+  // Append `path` (no null terminator required) into pathPool with a
+  // trailing '\0'. Returns the offset where the path's first byte landed.
+  // The pool may reallocate; callers must not hold raw c_str() / pathOf()
+  // pointers across calls to appendPath().
+  uint32_t appendPath(std::string_view path);
 };

--- a/src/SeriesIndex.cpp
+++ b/src/SeriesIndex.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 
 namespace {
 constexpr char SERIES_INDEX_FILE[] = "/.crosspoint/series_index.json";
@@ -13,6 +14,51 @@ constexpr uint8_t SERIES_INDEX_VERSION = 1;
 }  // namespace
 
 SeriesIndex SeriesIndex::instance;
+
+uint32_t SeriesIndex::appendString(std::string_view s) {
+  const uint32_t offset = static_cast<uint32_t>(stringPool.size());
+  stringPool.insert(stringPool.end(), s.begin(), s.end());
+  stringPool.push_back('\0');
+  return offset;
+}
+
+int SeriesIndex::indexOfPath(std::string_view path) const {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (path == pathOf(entries[i])) return static_cast<int>(i);
+  }
+  return -1;
+}
+
+void SeriesIndex::rebuildFrom(std::vector<ScratchEntry>& scratch) {
+  // Compute the rough pool size upfront so the new pool lands in a
+  // single contiguous allocation -- the whole point of this refactor is
+  // to give the heap allocator big atomic blocks to work with instead
+  // of N small ones.
+  size_t poolBytes = 0;
+  for (const auto& s : scratch) poolBytes += s.path.size() + s.name.size() + s.index.size() + 3;
+
+  std::vector<SeriesEntry> newEntries;
+  std::vector<char> newPool;
+  newEntries.reserve(scratch.size());
+  newPool.reserve(poolBytes);
+
+  for (auto& s : scratch) {
+    SeriesEntry e{};
+    e.pathOffset = static_cast<uint32_t>(newPool.size());
+    newPool.insert(newPool.end(), s.path.begin(), s.path.end());
+    newPool.push_back('\0');
+    e.nameOffset = static_cast<uint32_t>(newPool.size());
+    newPool.insert(newPool.end(), s.name.begin(), s.name.end());
+    newPool.push_back('\0');
+    e.indexOffset = static_cast<uint32_t>(newPool.size());
+    newPool.insert(newPool.end(), s.index.begin(), s.index.end());
+    newPool.push_back('\0');
+    newEntries.push_back(e);
+  }
+
+  entries.swap(newEntries);
+  stringPool.swap(newPool);
+}
 
 void SeriesIndex::begin() {
   if (jsonLoaded) return;
@@ -22,32 +68,52 @@ void SeriesIndex::begin() {
 
 void SeriesIndex::record(const std::string& path, const std::string& name, const std::string& index) {
   if (path.empty()) return;
-  auto it = byPath.find(path);
-  if (it != byPath.end() && it->second.name == name && it->second.index == index) {
-    return;  // no-op: already recorded with same values, skip disk write.
+  const int existing = indexOfPath(path);
+  if (existing >= 0) {
+    const SeriesEntry& e = entries[existing];
+    if (name == nameOf(e) && index == indexOf(e)) {
+      // no-op: already recorded with same values, skip disk write.
+      return;
+    }
   }
-  SeriesEntry e;
-  e.path = path;
-  e.name = name;
-  e.index = index;
-  byPath[path] = std::move(e);
+
+  // Build a scratch list off the current pool, mutate the target entry,
+  // then rebuild atomically. The rebuild guarantees the new pool is one
+  // fresh contiguous block (matches LibraryIndex's pattern + reasoning).
+  std::vector<ScratchEntry> scratch;
+  scratch.reserve(entries.size() + 1);
+  for (const auto& e : entries) {
+    scratch.push_back({pathOf(e), nameOf(e), indexOf(e)});
+  }
+  if (existing >= 0) {
+    scratch[existing].name = name;
+    scratch[existing].index = index;
+  } else {
+    scratch.push_back({path, name, index});
+  }
+  rebuildFrom(scratch);
   saveToFile();
 }
 
-bool SeriesIndex::hasBeenChecked(const std::string& path) const {
-  return byPath.find(path) != byPath.end();
-}
+bool SeriesIndex::hasBeenChecked(const std::string& path) const { return indexOfPath(path) >= 0; }
 
 const SeriesEntry* SeriesIndex::find(const std::string& path) const {
-  auto it = byPath.find(path);
-  if (it == byPath.end()) return nullptr;
-  return &it->second;
+  const int i = indexOfPath(path);
+  if (i < 0) return nullptr;
+  return &entries[i];
 }
 
 void SeriesIndex::forgetPath(const std::string& path) {
-  if (byPath.erase(path) > 0) {
-    saveToFile();
+  const int existing = indexOfPath(path);
+  if (existing < 0) return;
+  std::vector<ScratchEntry> scratch;
+  scratch.reserve(entries.size());
+  for (size_t i = 0; i < entries.size(); ++i) {
+    if (static_cast<int>(i) == existing) continue;
+    scratch.push_back({pathOf(entries[i]), nameOf(entries[i]), indexOf(entries[i])});
   }
+  rebuildFrom(scratch);
+  saveToFile();
 }
 
 std::string SeriesIndex::seriesKey(const std::string& rawName) {
@@ -109,21 +175,27 @@ bool SeriesIndex::loadFromFile() {
     LOG_ERR("SER", "series_index.json parse error: %s", err.c_str());
     return false;
   }
-  byPath.clear();
+
+  // Stage entries into a scratch list, then rebuild atomically so the
+  // final entries + stringPool land in single contiguous allocations
+  // (the ArduinoJson DOM already pinned ~the JSON bytes; once we're done
+  // staging the scratch list goes out of scope and frees those, leaving
+  // only our compact pool behind).
+  std::vector<ScratchEntry> scratch;
   JsonArrayConst arr = doc["books"];
   if (!arr.isNull()) {
-    byPath.reserve(arr.size());
+    scratch.reserve(arr.size());
     for (JsonObjectConst entry : arr) {
-      const std::string path = entry["path"] | std::string("");
-      if (path.empty()) continue;
-      SeriesEntry e;
-      e.path = path;
-      e.name = entry["name"] | std::string("");
-      e.index = entry["index"] | std::string("");
-      byPath[path] = std::move(e);
+      ScratchEntry s;
+      s.path = entry["path"] | std::string("");
+      if (s.path.empty()) continue;
+      s.name = entry["name"] | std::string("");
+      s.index = entry["index"] | std::string("");
+      scratch.push_back(std::move(s));
     }
   }
-  LOG_DBG("SER", "Loaded series index with %zu entries", byPath.size());
+  rebuildFrom(scratch);
+  LOG_DBG("SER", "Loaded series index with %zu entries", entries.size());
   return true;
 }
 
@@ -132,11 +204,11 @@ bool SeriesIndex::saveToFile() const {
   JsonDocument doc;
   doc["version"] = SERIES_INDEX_VERSION;
   JsonArray arr = doc["books"].to<JsonArray>();
-  for (const auto& kv : byPath) {
+  for (const auto& e : entries) {
     JsonObject entry = arr.add<JsonObject>();
-    entry["path"] = kv.second.path;
-    entry["name"] = kv.second.name;
-    entry["index"] = kv.second.index;
+    entry["path"] = pathOf(e);
+    entry["name"] = nameOf(e);
+    entry["index"] = indexOf(e);
   }
   String json;
   serializeJson(doc, json);

--- a/src/SeriesIndex.h
+++ b/src/SeriesIndex.h
@@ -1,6 +1,7 @@
 #pragma once
+#include <cstdint>
 #include <string>
-#include <unordered_map>
+#include <string_view>
 #include <vector>
 
 // CrumBLE — per-book series metadata cache, persistent across reboots.
@@ -21,18 +22,32 @@
 // `seriesIndex` is stored as a string (matches aalu) so "1", "1.5",
 // "VII", or "Vol. 3" round-trip exactly for display. Sorting uses a
 // parsed-numeric path with a string-fallback comparator.
+//
+// Memory shape: paths + names + indices are pooled into a single
+// contiguous std::vector<char> (each null-terminated). Each entry holds
+// 3 uint32_t offsets into the pool. This avoids the heap fragmentation
+// that the original 4-std::string-per-entry layout caused -- see the
+// LibraryIndex doc comment for the full diagnosis. Same fix, applied
+// to the next-most-fragmenting per-book metadata store.
 
 struct SeriesEntry {
-  std::string path;   // absolute book path
-  std::string name;   // raw series name as it appeared in OPF
-  std::string index;  // raw series_index / group-position (string)
+  // Offsets into SeriesIndex::stringPool of this entry's null-terminated
+  // strings. Dereference via SeriesIndex::pathOf / nameOf / indexOf;
+  // the pool's contents are stable for the lifetime of one
+  // load/record cycle. Records that change a string's length trigger
+  // an atomic rebuild rather than mutating in place.
+  uint32_t pathOffset = 0;
+  uint32_t nameOffset = 0;
+  uint32_t indexOffset = 0;
 };
 
 class SeriesIndex {
   static SeriesIndex instance;
-  // path → entry. unordered_map for O(1) by-path lookup during shelf
-  // resolution (which is on the hot path).
-  std::unordered_map<std::string, SeriesEntry> byPath;
+  std::vector<SeriesEntry> entries;
+  // Single contiguous backing buffer for every entry's strings (path,
+  // name, index), null-terminated and packed back-to-back. The mutating
+  // operations (record / forgetPath / loadFromFile) rebuild it atomically.
+  std::vector<char> stringPool;
   bool jsonLoaded = false;
 
   SeriesIndex() = default;
@@ -53,9 +68,14 @@ class SeriesIndex {
   // we found series info or not).
   bool hasBeenChecked(const std::string& path) const;
 
-  // Returns the entry for `path` or nullptr if we haven't checked it
-  // yet. Caller can read .name (empty = no series) and .index.
+  // Returns the entry index for `path`, or nullopt if we haven't checked
+  // it yet. Caller uses pathOf/nameOf/indexOf to read the underlying
+  // strings. The returned index is invalidated by any record() /
+  // forgetPath() call.
   const SeriesEntry* find(const std::string& path) const;
+  const char* pathOf(const SeriesEntry& e) const { return stringPool.data() + e.pathOffset; }
+  const char* nameOf(const SeriesEntry& e) const { return stringPool.data() + e.nameOffset; }
+  const char* indexOf(const SeriesEntry& e) const { return stringPool.data() + e.indexOffset; }
 
   // Removes the entry — used when a book is deleted from disk.
   void forgetPath(const std::string& path);
@@ -75,4 +95,21 @@ class SeriesIndex {
  private:
   bool loadFromFile();
   bool saveToFile() const;
+
+  // Append a single null-terminated string into stringPool. Returns the
+  // offset of its first byte. Callers must not retain raw pointers
+  // across appendString() calls -- the pool may reallocate.
+  uint32_t appendString(std::string_view s);
+  // Linear-scan find by path. Returns -1 if not found. Cheap at the
+  // library sizes we run (≤ a few hundred entries) and avoids the
+  // hash-map overhead the old layout used.
+  int indexOfPath(std::string_view path) const;
+  // Rebuild entries + stringPool from a scratch list of {path, name,
+  // index} triples. Used by mutating operations that can't update in
+  // place (e.g. record() with a longer replacement name -- in-place
+  // would corrupt subsequent entries' offsets).
+  struct ScratchEntry {
+    std::string path, name, index;
+  };
+  void rebuildFrom(std::vector<ScratchEntry>& scratch);
 };


### PR DESCRIPTION
## Summary

CrumBLE users with libraries in the ~30-50 book range were hitting a hard wedge when entering File Transfer: the UI stopped responding to back-tap and the only recovery was a forced reboot. On-device serial captured a fragmented-heap pattern -- ~14 KB free but only 6 KB max contiguous block, well below the 8-16 KB chunks WiFi + AsyncWebServer want.

The fragmentation source was per-book metadata structures (\`LibraryIndex\`, \`SeriesIndex\`) holding their fields as individual \`std::string\`s. N books = N (or N×3) small heap allocations scattered across the heap; when the activity later \`releaseMemory()\`'d them, the freed slots stayed scattered between other longer-lived allocations and the allocator couldn't coalesce them back into a single large contiguous hole.

This PR pools each metadata store's strings into a single contiguous \`std::vector<char>\` buffer (each entry holds a uint32_t offset). One big allocation instead of N small ones; releaseMemory returns ONE large hole instead of N scattered holes.

## Measured impact

Side-by-side at the same File Transfer flow with a 32-book library:

| Moment | v3.7.2 baseline | After this PR |
|---|---|---|
| Idle home | 87/63 KB (73%) | 80/65 KB (81%) |
| Pre WiFi connect | — | 61/57 KB (93%) |
| Post HTML page served | 13/6 KB (47%) | 26/23 KB (89%) |
| **Min Free over whole session** | **~1-2 KB (OOM cliff)** | **14.7 KB** |

The Min Free is the headline -- v3.7.2's ~1-2 KB low is where back-tap stops responding (the activity-transition redraw alloc fails). 14.7 KB gives a 7-10x safety margin. The freeze is gone.

Practical impact: safe library size for File Transfer should jump from ~30-32 books to roughly 90-150 books before hitting the same threshold the old layout hit at 32.

## Two commits

1. **\`refactor(library): pool per-entry paths into a single contiguous buffer\`** -- LibraryIndex. Each \`LibraryEntry\` was a \`std::string path\` + 12 POD bytes; now it's a \`uint32_t pathOffset\` into a single \`std::vector<char> pathPool\`. Rescan + load atomically rebuild rather than incrementally append (so string_view diff-lookup keys can't dangle mid-mutation).
2. **\`refactor(series): pool per-entry strings into a single contiguous buffer\`** -- SeriesIndex. Same pattern for the 3 strings per entry (path, name, index). Lookup switched from unordered_map to linear scan -- at the library sizes we run, the hash overhead was paying for itself less than the per-entry allocation churn. Public \`SeriesEntry\` fields became accessor methods (\`SeriesIndex::pathOf\` / \`nameOf\` / \`indexOf\` returning \`const char*\`); the only external caller was \`CollectionsStore.cpp\`, updated in the same commit.

## Out of scope / follow-up candidates

\`RecentBooksStore\` follows the same pattern (4 std::strings per entry, capped at 18 entries) and would mostly help heap stability in places OTHER than file transfer (BLE-while-reading, home → reader transitions). Decided to defer: the diff would touch 10+ theme files (every \`RecentBook\` field access in MinimalTheme / LyraTheme / LyraFlowTheme / LyraCarouselTheme / Lyra3CoversTheme / RoundedRaffTheme / BaseTheme / RecentBookProgress / JsonSettingsIO), and the file-transfer cliff is already fixed without it. Chip-worthy if BLE-during-reading shows fragmentation symptoms in the future.

## Test plan

- [x] \`pio run -e tiny\` clean (no flash/RAM regression).
- [x] On-device serial capture of File Transfer flow on the same 32-book library that was freezing -- both Home → File Transfer → page load → back-out cycles complete cleanly. Captured numbers in the table above.
- [x] Repeated the test twice (boot + flow + back + flow + back) -- no degradation across reuse.
- [ ] On-device home/reader/collections smoke test post-merge to make sure no theme rendering changed.