### PR TITLE
build: CRUMBLE_OMIT_WASM=1 strips prebake blobs (post-v4.0.0 follow-up)

### DIFF
--- a/scripts/embed_wasm.py
+++ b/scripts/embed_wasm.py
@@ -33,7 +33,16 @@ TARGETS = [
 
 
 def embed(src_path: Path, identifier: str) -> None:
-    if not src_path.exists():
+    # CRUMBLE_OMIT_WASM=1 forces stub generation even when the WASM is
+    # built. Used for release builds where we want the firmware binary
+    # to stay small enough to leave OTA headroom; the device-side
+    # /js/crumble-prebake.* handlers fall through to a 404 and the web
+    # optimizer falls back to its CDN-loaded variant.
+    if os.environ.get("CRUMBLE_OMIT_WASM") == "1":
+        print(f"[embed_wasm] skip {src_path.name}: CRUMBLE_OMIT_WASM=1")
+        compressed = b""
+        original_size = 0
+    elif not src_path.exists():
         # The WASM build is optional -- if the developer hasn't run
         # tools/crumble-prebake/build-wash.sh, emit a tiny stub header
         # so the firmware still compiles. The /js/crumble-prebake.*


### PR DESCRIPTION
Adds a build-env switch `CRUMBLE_OMIT_WASM=1` to `scripts/embed_wasm.py` so the prebake JS+WASM PROGMEM blobs (~920 KB combined) are replaced with empty stubs.

The v4.0.0 release binary was rebuilt with this flag set and re-uploaded to the release as `crumble-firmware-4.0.0.bin` (6.45 MB) so it matches the historical size profile (v3.7.3 was 6.48 MB) instead of the with-WASM 7.30 MB build.

Development builds without the env var keep the embed for offline-capable web-optimizer use. The runtime handlers already gracefully 404 when the PROGMEM size is 0.