### PR TITLE
build(tiny): OMIT_EMOJI_FONTS so v4.0.0 fits in 6.25 MB OTA slot

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -179,6 +179,13 @@ build_flags =
   -DOMIT_ITTY_BITTY_FONT
   -DOMIT_XLARGE_FONT
   -DOMIT_HUGE_FONT
+  ; CrumBLE: dropped emoji + symbol + CJK-fallback fonts to keep the
+  ; firmware under the 6.25 MB OTA partition size used by stock CrossPoint
+  ; / CrossInk / pre-v3.0.0 CrumBLE. Saves ~470 KB. Effect: no inline
+  ; emoji rendering in EPUBs (rare in normal books); CJK fallback gone
+  ; (CrumBLE doesn't target CJK reading anyway). Users who want emoji
+  ; should build a custom env without this flag.
+  -DOMIT_EMOJI_FONTS
 
 ; Omits smaller font sizes (8px, 10px, and 12px) to support Extra Large/Huge and emojis.
 [env:xlarge]


### PR DESCRIPTION
A reporter on a stock-partition device hit `Firmware too large: 6757120 bytes won't fit in app1 (6553600 bytes)` trying to OTA to v4.0.0. The 6.25 MB partition is what stock CrossPoint / CrossInk / pre-v3.0.0 CrumBLE use; v3.0.0+ widened it to 7.5 MB but OTA can't repartition.

Adding `-DOMIT_EMOJI_FONTS` to the `tiny` env drops the emoji+symbol+CJK-fallback fonts (uses existing pre-generated `noemoji/` variants of each reading font). Saves ~470 KB.

**Result:** v4.0.0 binary now 6,284,672 bytes (5.99 MB) — under the 6.25 MB limit with ~268 KB headroom. Release asset already rebuilt + re-uploaded with this flag set.