### PR TITLE
build: OMIT_CHAREINK_FONT for OTA-fit 4.0.0 slim binary

### DIFF
--- a/lib/EpdFont/builtinFonts/all.h
+++ b/lib/EpdFont/builtinFonts/all.h
@@ -73,6 +73,13 @@
 #include BUILTIN_READING_FONT_HEADER(bitter_20_regular)
 #endif
 
+// CrumBLE: OMIT_CHAREINK_FONT drops the entire CharEink family. Saves
+// ~700-900 KB binary -- used in the OTA-fit "slim" release build so
+// the firmware stays under the 6.25 MB legacy partition. The picker
+// in SettingsList.h omits the CharEink option in lockstep; users who
+// had CharEink selected before this flag turned on fall back to
+// Bitter via getFallbackReaderFontIdForFamily.
+#ifndef OMIT_CHAREINK_FONT
 #ifndef OMIT_TEENSY_FONT
 #include BUILTIN_READING_FONT_HEADER(charein_8_bold)
 #include BUILTIN_READING_FONT_HEADER(charein_8_bolditalic)
@@ -121,6 +128,7 @@
 #include BUILTIN_READING_FONT_HEADER(charein_20_italic)
 #include BUILTIN_READING_FONT_HEADER(charein_20_regular)
 #endif
+#endif  // OMIT_CHAREINK_FONT
 
 #ifndef OMIT_TEENSY_FONT
 #include BUILTIN_READING_FONT_HEADER(lexenddeca_8_bold)

--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -136,6 +136,12 @@ CrossPointSettings::FONT_SIZE firstAvailableReaderFontSize() {
 int getFallbackReaderFontIdForFamily(const CrossPointSettings::FONT_FAMILY family) {
   switch (family) {
     case CrossPointSettings::CHAREINK:
+#ifdef OMIT_CHAREINK_FONT
+      // CharEink family is OMIT'd; fall through to the BITTER case below
+      // so users with CHAREINK saved as their preference still get a
+      // legible reader font instead of a missing-font crash.
+      [[fallthrough]];
+#else
 #ifndef OMIT_TINY_FONT
       return CHAREINK_10_FONT_ID;
 #elif !defined(OMIT_SMALL_FONT)
@@ -155,6 +161,7 @@ int getFallbackReaderFontIdForFamily(const CrossPointSettings::FONT_FAMILY famil
 #else
 #error "No reader fonts enabled for CHAREINK"
 #endif
+#endif  // OMIT_CHAREINK_FONT
     case CrossPointSettings::BITTER:
 #ifndef OMIT_TINY_FONT
       return BITTER_10_FONT_ID;
@@ -761,6 +768,11 @@ int CrossPointSettings::getReaderFontId() const {
       }
       return getFallbackReaderFontIdForFamily(LEXENDDECA);
     case CHAREINK:
+#ifdef OMIT_CHAREINK_FONT
+      // CharEink family is OMIT'd; fall back to BITTER for users with
+      // a stale CHAREINK preference (silent migration, no crash).
+      return getFallbackReaderFontIdForFamily(BITTER);
+#else
       switch (effectiveSize) {
 #ifndef OMIT_TEENSY_FONT
         case TEENSY:
@@ -800,6 +812,7 @@ int CrossPointSettings::getReaderFontId() const {
 #endif
       }
       return getFallbackReaderFontIdForFamily(CHAREINK);
+#endif  // OMIT_CHAREINK_FONT
     case BITTER:
       switch (effectiveSize) {
 #ifndef OMIT_TEENSY_FONT

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -139,8 +139,14 @@ inline uint8_t closestBuiltinFontSizeIndex(const uint8_t targetPointSize) {
 // Build the font family setting dynamically. When registry is non-null, SD card fonts
 // are appended after the built-in fonts. Otherwise only built-in fonts are listed.
 inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
-  // Built-in font labels (StrId)
-  std::vector<StrId> enumValues = {StrId::STR_LEXEND_DECA, StrId::STR_BITTER, StrId::STR_CHAREINK};
+  // Built-in font labels (StrId). CrumBLE: OMIT_CHAREINK_FONT drops the
+  // CharEink option from the picker so the slim OTA build doesn't show
+  // a font family that isn't actually embedded.
+  std::vector<StrId> enumValues = {StrId::STR_LEXEND_DECA, StrId::STR_BITTER,
+#ifndef OMIT_CHAREINK_FONT
+                                   StrId::STR_CHAREINK
+#endif
+  };
   // Runtime string labels for SD card fonts
   std::vector<std::string> enumStringValues;
 
@@ -163,7 +169,9 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
   if (sdFontCount > 0) {
     allStringValues.push_back(I18N.get(StrId::STR_LEXEND_DECA));
     allStringValues.push_back(I18N.get(StrId::STR_BITTER));
+#ifndef OMIT_CHAREINK_FONT
     allStringValues.push_back(I18N.get(StrId::STR_CHAREINK));
+#endif
     allStringValues.insert(allStringValues.end(), enumStringValues.begin(), enumStringValues.end());
   }
 
@@ -333,7 +341,12 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
     // Built-in font-family entry. Replaced per-call with a registry-aware
     // version when SD fonts are installed.
     add(SettingInfo::Enum(StrId::STR_FONT_FAMILY, &CrossPointSettings::fontFamily,
-                          {StrId::STR_LEXEND_DECA, StrId::STR_BITTER, StrId::STR_CHAREINK}, "fontFamily",
+                          {StrId::STR_LEXEND_DECA, StrId::STR_BITTER,
+#ifndef OMIT_CHAREINK_FONT
+                           StrId::STR_CHAREINK
+#endif
+                          },
+                          "fontFamily",
                           StrId::STR_CAT_READER));
     add(buildBuiltinFontSizeSetting());
     // CrumBLE: "Download Font Size Range" (sdFontSizeRange) is omitted from the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,8 @@ EpdFont lexenddeca14BoldItalicFont(&lexenddeca_14_bolditalic);
 EpdFontFamily lexenddeca14FontFamily(&lexenddeca14RegularFont, &lexenddeca14BoldFont, &lexenddeca14ItalicFont,
                                      &lexenddeca14BoldItalicFont);
 #endif
+// CrumBLE: OMIT_CHAREINK_FONT drops the entire CharEink family (see all.h).
+#ifndef OMIT_CHAREINK_FONT
 #ifndef OMIT_TEENSY_FONT
 EpdFont charein8RegularFont(&charein_8_regular);
 EpdFont charein8BoldFont(&charein_8_bold);
@@ -174,6 +176,7 @@ EpdFont charein20BoldItalicFont(&charein_20_bolditalic);
 EpdFontFamily charein20FontFamily(&charein20RegularFont, &charein20BoldFont, &charein20ItalicFont,
                                   &charein20BoldItalicFont);
 #endif
+#endif  // OMIT_CHAREINK_FONT
 #ifndef OMIT_TEENSY_FONT
 EpdFont lexenddeca8RegularFont(&lexenddeca_8_regular);
 EpdFont lexenddeca8BoldFont(&lexenddeca_8_bold);
@@ -867,6 +870,7 @@ void setupDisplayAndFonts(bool seamless = false) {
   fontCacheManager.setFontDecompressor(&fontDecompressor);
   renderer.setFontCacheManager(&fontCacheManager);
 
+#ifndef OMIT_CHAREINK_FONT
 #ifndef OMIT_TEENSY_FONT
   renderer.insertFont(CHAREINK_8_FONT_ID, charein8FontFamily);
 #endif
@@ -891,6 +895,7 @@ void setupDisplayAndFonts(bool seamless = false) {
 #ifndef OMIT_HUGE_FONT
   renderer.insertFont(CHAREINK_20_FONT_ID, charein20FontFamily);
 #endif
+#endif  // OMIT_CHAREINK_FONT
 
 #ifndef OMIT_TEENSY_FONT
   renderer.insertFont(LEXENDDECA_8_FONT_ID, lexenddeca8FontFamily);


### PR DESCRIPTION
Adds a build flag that drops the CharEink font family. Used to produce the slim `crumble-firmware-4.0.0.bin` release asset that fits in the legacy 6.25 MB OTA partition.

**Result:** v4.0.0 release now ships two variants:
- `crumble-firmware-4.0.0.bin` — 6.08 MB, two fonts (Bitter, Lexend Deca), OTA-friendly
- `crumble-firmware-4.0.0-full-needs-USB-flash.bin` — 6.85 MB, all three fonts (Bitter, Lexend Deca, CharEink), requires USB flash

Users who saved CHAREINK as their fontFamily preference fall back to Bitter via getFallbackReaderFontIdForFamily — graceful migration, no missing-font crash.