### PR TITLE
feat(ota): wire OTA to imshentastic/CrumBLE; bump to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [crumble-v4.1.0] - 2026-06-04
+
+### Added
+- **OTA updates now pull from CrumBLE's own GitHub releases** (`imshentastic/CrumBLE`) instead of upstream CrossInk-Carousel. Once you're on v4.1.0, `Settings → Check for Updates` finds every future CrumBLE release automatically — **this is the last manual flash you'll ever need**.
+  - The version comparison uses `CRUMBLE_VERSION` (4.1.0, 4.1.1, 4.2.0, ...) instead of upstream's `CROSSINK_VERSION` (only bumped when CrumBLE rebases onto a new CrossInk).
+  - The asset matcher refuses any `crumble-firmware-X.Y.Z-full-needs-USB-flash.bin` variant — those binaries are intentionally too large for the legacy 6.25 MB OTA partition and would brick anyone who tried to OTA them. Users who want CharEink built-in continue to flash the full binary manually via crosspointreader.com/#flash-tools.
+  - The OTA Update activity shows `CrumBLE X.Y.Z → 4.1.0` (stripped of the `crumble-v` tag prefix) so the UI reads cleanly.
+
+### Changed
+- Version bump 4.0.1 → 4.1.0 because "OTA actually works now" is a meaningful new capability worth a minor-version bump.
+
 ## [crumble-v4.0.1] - 2026-06-04
 
 ### Changed

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ crossink_version = 1.3.0
 ;         the last book page in as a background unless you slept from a book.
 ;         Also adds X4/X3 simulator envs + tooling (dev-only; X3 runtime support
 ;         already shipped in 3.0.0).
-crumble_version = 4.0.1
+crumble_version = 4.1.0
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -116,10 +116,20 @@ void OtaUpdateActivity::render(RenderLock&&) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_CHECKING_UPDATE));
   } else if (state == WAITING_CONFIRMATION) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NEW_UPDATE), true, EpdFontFamily::BOLD);
+    // CrumBLE: show CrumBLE's own version (CRUMBLE_VERSION) since the
+    // update is being pulled from imshentastic/CrumBLE's releases.
+    // Strip the "crumble-" tag prefix off the new-version display so it
+    // reads as "4.1.0" not "crumble-v4.1.0".
+    const char* newVersionDisplay = updater.getLatestVersion().c_str();
+    constexpr char tagPrefix[] = "crumble-";
+    if (strncmp(newVersionDisplay, tagPrefix, sizeof(tagPrefix) - 1) == 0) {
+      newVersionDisplay += sizeof(tagPrefix) - 1;
+    }
+    if (*newVersionDisplay == 'v' || *newVersionDisplay == 'V') ++newVersionDisplay;
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, top + height + metrics.verticalSpacing,
-                      (std::string(tr(STR_CURRENT_VERSION)) + CROSSINK_VERSION).c_str());
+                      (std::string(tr(STR_CURRENT_VERSION)) + CRUMBLE_VERSION).c_str());
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, top + height * 2 + metrics.verticalSpacing * 2,
-                      (std::string(tr(STR_NEW_VERSION)) + updater.getLatestVersion()).c_str());
+                      (std::string(tr(STR_NEW_VERSION)) + newVersionDisplay).c_str());
 
     const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -18,19 +18,25 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback, void*, s
 #include "network/WifiPowerSaveGuard.h"
 
 namespace {
+// CrumBLE: OTA points at imshentastic/CrumBLE's own releases. The
+// upstream CrossInk-Carousel URL would give CrumBLE users misleading
+// "no update" or accidentally downgrade them to upstream.
 #ifndef CROSSINK_OTA_RELEASE_URL
-#define CROSSINK_OTA_RELEASE_URL "https://api.github.com/repos/chintanvajariya/CrossInk-Carousel/releases/latest"
+#define CROSSINK_OTA_RELEASE_URL "https://api.github.com/repos/imshentastic/CrumBLE/releases/latest"
 #endif
 
 constexpr char latestReleaseUrl[] = CROSSINK_OTA_RELEASE_URL;
 
-#ifdef CROSSPOINT_FIRMWARE_VARIANT
-constexpr char firmwareAssetStem[] = "carousel-firmware-" CROSSPOINT_FIRMWARE_VARIANT;
-constexpr char firmwareAssetName[] = "carousel-firmware-" CROSSPOINT_FIRMWARE_VARIANT ".bin";
-#else
-constexpr char firmwareAssetStem[] = "carousel-firmware";
-constexpr char firmwareAssetName[] = "carousel-firmware.bin";
-#endif
+// CrumBLE: release assets are named "crumble-firmware-X.Y.Z.bin" (slim,
+// OTA-friendly) and "crumble-firmware-X.Y.Z-full-needs-USB-flash.bin"
+// (larger, USB-only). The matcher below treats only the slim variant as
+// an OTA target -- delivering the full to a 6.25 MB legacy OTA slot
+// would brick the device with "Firmware too large". The stem is just
+// "crumble-firmware" (no -tiny suffix) since CrumBLE has one shipping
+// variant per release.
+constexpr char firmwareAssetStem[] = "crumble-firmware";
+constexpr char firmwareAssetName[] = "crumble-firmware.bin";
+constexpr char fullVariantMarker[] = "-full-needs-USB-flash";
 
 constexpr char binSuffix[] = ".bin";
 constexpr size_t VERSION_SEGMENT_COUNT = 4;
@@ -116,8 +122,24 @@ bool endsWith(const char* value, const char* suffix) {
   return strcmp(value + valueLength - suffixLength, suffix) == 0;
 }
 
+// Substring search: does `haystack` contain `needle` anywhere? Cheap
+// O(n*m) is fine here -- asset names are ~96 chars max.
+bool containsSubstring(const char* haystack, const char* needle) {
+  if (haystack == nullptr || needle == nullptr) return false;
+  const size_t needleLen = strlen(needle);
+  if (needleLen == 0) return true;
+  for (const char* p = haystack; *p != '\0'; ++p) {
+    if (strncmp(p, needle, needleLen) == 0) return true;
+  }
+  return false;
+}
+
 bool isMatchingFirmwareAssetName(const char* assetName) {
   if (assetName == nullptr) return false;
+  // CrumBLE: refuse the -full-needs-USB-flash variant even though it
+  // matches our stem -- it intentionally overflows the legacy 6.25 MB
+  // OTA partition and would brick devices on that layout.
+  if (containsSubstring(assetName, fullVariantMarker)) return false;
   if (strcmp(assetName, firmwareAssetName) == 0) return true;
   if (!startsWith(assetName, firmwareAssetStem)) return false;
   if (assetName[strlen(firmwareAssetStem)] != '-') return false;
@@ -238,14 +260,33 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   return OK;
 }
 
+namespace {
+// CrumBLE release tags are "crumble-vX.Y.Z" (e.g. "crumble-v4.1.0").
+// parseVersion only handles optional 'v'/'V' + digits, so strip the
+// "crumble-" prefix before comparing -- otherwise every comparison
+// silently returns 0 (== no update) because parsing fails.
+const char* stripCrumbleTagPrefix(const char* tag) {
+  if (tag == nullptr) return tag;
+  constexpr char prefix[] = "crumble-";
+  constexpr size_t prefixLen = sizeof(prefix) - 1;
+  if (strncmp(tag, prefix, prefixLen) == 0) return tag + prefixLen;
+  return tag;
+}
+}  // namespace
+
 bool OtaUpdater::isUpdateNewer() const {
-  if (!updateAvailable || latestVersion.empty() || latestVersion == CROSSINK_VERSION) {
+  if (!updateAvailable || latestVersion.empty()) {
     return false;
   }
 
-  const int comparison = compareVersions(latestVersion.c_str(), CROSSINK_VERSION);
-  LOG_DBG("OTA", "Version comparison latest=%s current=%s result=%d", latestVersion.c_str(), CROSSINK_VERSION,
-          comparison);
+  // Compare CrumBLE versions (4.0.x / 4.1.x ...), not upstream CrossInk
+  // (which only bumps on rebase). Strip the "crumble-" tag prefix so
+  // parseVersion sees "vX.Y.Z" or "X.Y.Z".
+  const char* latest = stripCrumbleTagPrefix(latestVersion.c_str());
+  if (strcmp(latest, CRUMBLE_VERSION) == 0) return false;
+
+  const int comparison = compareVersions(latest, CRUMBLE_VERSION);
+  LOG_DBG("OTA", "Version comparison latest=%s current=%s result=%d", latest, CRUMBLE_VERSION, comparison);
   return comparison > 0;
 }
 


### PR DESCRIPTION
After this manual flash, every future CrumBLE release auto-updates via the device's Settings -> Check for Updates flow.

Three-line code change + asset-matcher safety guard + UI display fix in `src/network/OtaUpdater.cpp` and `src/activities/settings/OtaUpdateActivity.cpp`. See commit message for details.

Version bump 4.0.1 -> 4.1.0 because 'OTA actually works now' is a meaningful new capability worth a minor-version bump.